### PR TITLE
feat(admin): add back button from performance detail to list

### DIFF
--- a/app/admin/performances/[performanceId]/page.tsx
+++ b/app/admin/performances/[performanceId]/page.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -27,9 +28,16 @@ export default async function PerformanceDetail(props: { params: Promise<{ perfo
     return (
         <>
             <div className={"flex justify-between"}>
-                <h1 className="mb-4 text-2xl font-bold">
-                    {performance.name} {formatDate(performance.date)}
-                </h1>
+                <div className={"flex items-stretch"}>
+                    <Button variant="ghost" size="icon" asChild className={"h-auto"}>
+                        <Link href={"/admin"}>
+                            <ChevronLeft size={28} />
+                        </Link>
+                    </Button>
+                    <h1 className="mb-4 text-2xl font-bold">
+                        {performance.name} {formatDate(performance.date)}
+                    </h1>
+                </div>
                 <PerformanceStateToggle performanceId={performance.id} defaultState={performance.state} />
             </div>
             <div className={"flex justify-between gap-2"}>


### PR DESCRIPTION
Adds a ghost `ChevronLeft` icon button before the performance title on the performance detail page that links back to the performances list (`/admin`). It mirrors the existing back-navigation pattern used on the question detail page, and `PerformanceStateToggle` stays right-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)