### PR TITLE
feat(admin): create and delete voting question pools

### DIFF
--- a/api/question-pools.api.ts
+++ b/api/question-pools.api.ts
@@ -1,6 +1,8 @@
 "use server";
 import { revalidatePath } from "next/cache";
 
+import type { ServerActionResult } from "@/api/types.api";
+import type { QuestionPool } from "@/api/types.api";
 import { createClient } from "@/utils/supabase/server";
 
 export const fetchAvailablePools = async (performanceId: number) => {
@@ -41,4 +43,45 @@ export const setPoolAudienceVisibility = async (
     await supabase.from("questions_pool").update({ audience_visibility: visibility }).eq("id", poolId);
     revalidatePath(`/admin/performances/${performanceId}/question-pools`);
     revalidatePath(`/admin/performances/${performanceId}/question-pools/${poolId}`);
+};
+
+export const createPool = async (performanceId: number, name: string): Promise<ServerActionResult<QuestionPool>> => {
+    const supabase = await createClient();
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+
+    const { data, error } = await supabase
+        .from("questions_pool")
+        .insert({ performance_id: performanceId, name: name.trim() || null })
+        .select()
+        .single();
+
+    if (error) return { success: false, error: error.message };
+
+    revalidatePath(`/admin/performances/${performanceId}/question-pools`);
+    return { success: true, data };
+};
+
+export const deletePool = async (poolId: number, performanceId: number): Promise<ServerActionResult<void>> => {
+    const supabase = await createClient();
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+
+    const { count, error: countError } = await supabase
+        .from("questions")
+        .select("id", { count: "exact", head: true })
+        .eq("pool_id", poolId);
+
+    if (countError) return { success: false, error: countError.message };
+    if (count && count > 0) return { success: false, error: "Skupinu nelze smazat, protože obsahuje otázky." };
+
+    const { error } = await supabase.from("questions_pool").delete().eq("id", poolId);
+    if (error) return { success: false, error: error.message };
+
+    revalidatePath(`/admin/performances/${performanceId}/question-pools`);
+    return { success: true, data: undefined };
 };

--- a/app/admin/performances/[performanceId]/question-pools/[poolId]/page.tsx
+++ b/app/admin/performances/[performanceId]/question-pools/[poolId]/page.tsx
@@ -4,8 +4,10 @@ import { notFound } from "next/navigation";
 
 import { fetchQuestionPool } from "@/api/question-pools.api";
 import { PoolVotingAnswers } from "@/components/admin/answers/PoolVotingAnswers";
+import { DeletePoolButton } from "@/components/admin/question-pools/DeletePoolButton";
 import { PoolAudienceStateToggle } from "@/components/admin/question-pools/PoolAudienceStateToggle";
 import { Button } from "@/components/ui/Button";
+import { createClient } from "@/utils/supabase/server";
 
 export default async function QuestionPoolDetail(props: { params: Promise<{ poolId: string }> }) {
     const params = await props.params;
@@ -16,13 +18,20 @@ export default async function QuestionPoolDetail(props: { params: Promise<{ pool
         notFound();
     }
 
+    const supabase = await createClient();
+    const { count } = await supabase
+        .from("questions")
+        .select("id", { count: "exact", head: true })
+        .eq("pool_id", poolId);
+    const hasQuestions = (count ?? 0) > 0;
+
     return (
         <>
             <header className={"mb-4"}>
                 <div className={"flex justify-between"}>
                     <div className={"flex items-stretch"}>
                         <Button variant="ghost" size="icon" className={"h-auto"} asChild>
-                            <Link href={`/admin/performances/${pool.performance_id}`}>
+                            <Link href={`/admin/performances/${pool.performance_id}/question-pools`}>
                                 <ChevronLeft size={28} />
                             </Link>
                         </Button>
@@ -40,6 +49,11 @@ export default async function QuestionPoolDetail(props: { params: Promise<{ pool
             <aside className={"mt-4"}>
                 <PoolVotingAnswers poolId={pool.id} performanceId={pool.performance_id} />
             </aside>
+            {!hasQuestions && (
+                <div className={"mt-12"}>
+                    <DeletePoolButton pool={pool} />
+                </div>
+            )}
         </>
     );
 }

--- a/app/admin/performances/[performanceId]/question-pools/new/page.tsx
+++ b/app/admin/performances/[performanceId]/question-pools/new/page.tsx
@@ -1,0 +1,46 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createPool } from "@/api/question-pools.api";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+
+export default async function NewQuestionPool(props: { params: Promise<{ performanceId: string }> }) {
+    const params = await props.params;
+    const performanceId = parseInt(params.performanceId);
+
+    async function handleSubmit(formData: FormData) {
+        "use server";
+        const name = formData.get("name") as string;
+        const result = await createPool(performanceId, name);
+        if (result.success) {
+            redirect(`/admin/performances/${performanceId}/question-pools/${result.data.id}`);
+        }
+    }
+
+    return (
+        <>
+            <header className={"mb-4 flex items-center gap-2"}>
+                <Button variant="ghost" size="icon" asChild>
+                    <Link href={`/admin/performances/${performanceId}/question-pools`}>
+                        <ChevronLeft size={28} />
+                    </Link>
+                </Button>
+                <h1 className="text-2xl font-bold">Nová skupina otázek</h1>
+            </header>
+            <article className={"pb-8"}>
+                <form action={handleSubmit} className={"flex flex-col gap-4"}>
+                    <div className={"flex flex-col gap-2"}>
+                        <Label htmlFor="name">Název skupiny</Label>
+                        <Input id="name" name="name" required maxLength={255} autoFocus />
+                    </div>
+                    <div>
+                        <Button type="submit">Vytvořit skupinu</Button>
+                    </div>
+                </form>
+            </article>
+        </>
+    );
+}

--- a/app/admin/performances/[performanceId]/question-pools/page.tsx
+++ b/app/admin/performances/[performanceId]/question-pools/page.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Eye, EyeOff } from "lucide-react";
+import { ChevronLeft, Eye, EyeOff, Plus } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -32,6 +32,12 @@ export default async function QuestionPools(props: { params: Promise<{ performan
                         </h1>
                     </div>
                 </div>
+                <Button asChild>
+                    <Link href={`/admin/performances/${performanceId}/question-pools/new`}>
+                        <Plus size={16} />
+                        Nová skupina
+                    </Link>
+                </Button>
             </div>
             <List>
                 {pools.map((pool) => (

--- a/components/admin/question-pools/DeletePoolButton.tsx
+++ b/components/admin/question-pools/DeletePoolButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deletePool } from "@/api/question-pools.api";
+import type { QuestionPool } from "@/api/types.api";
+import { Button } from "@/components/ui/Button";
+
+type Props = {
+    pool: QuestionPool;
+};
+
+export const DeletePoolButton = ({ pool }: Props) => {
+    const router = useRouter();
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleDelete = async () => {
+        setLoading(true);
+        setError(null);
+        const result = await deletePool(pool.id, pool.performance_id);
+        if (result.success) {
+            router.push(`/admin/performances/${pool.performance_id}/question-pools`);
+        } else {
+            setError(result.error);
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className={"flex flex-col gap-2"}>
+            <Button variant="outline" className={"border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"} onClick={handleDelete} disabled={loading}>
+                <Trash2 size={16} />
+                {loading ? "Mazání…" : "Smazat skupinu"}
+            </Button>
+            {error && (
+                <p className={"text-sm text-destructive"} role="alert">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.553.0",
     "next": "16.2.3",
     "qrcode.react": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       lucide-react:
         specifier: ^0.553.0
         version: 0.553.0(react@19.2.0)
@@ -2497,6 +2500,11 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -7400,6 +7408,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
 
   date-fns@4.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add `createPool` and `deletePool` server actions with auth checks; delete is guarded against pools that still contain questions
- New pool creation page (`/question-pools/new`) with a name field that redirects to the new pool's detail on success
- Delete button (outline destructive style) rendered at the bottom of the pool detail page, only visible when the pool has no questions assigned
- Fix pool detail back button to navigate to the pools list instead of the performance detail

Also includes earlier changes on this branch: timezone fixes, grayscale removal for player photos, and upcoming performances display improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)