### PR TITLE
refactor(questions): collapse question state to hidden/active/locked

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -74,7 +74,7 @@ TDD MUST be followed for all new features and bug fixes. Write tests, get user a
 
 The application serves three distinct roles with zero UI overlap:
 
-**Admin** (`/admin/*`): Performance management, question lifecycle control (draft→active→locked→answered), answer review, visibility toggles. Requires Supabase authentication. Desktop-first layout via `TabletContainer`.
+**Admin** (`/admin/*`): Performance management, question lifecycle control (hidden→active→locked), answer review, visibility toggles. Requires Supabase authentication. Desktop-first layout via `TabletContainer`.
 
 **Audience** (`/audience`): Passive display for projector/screen. Shows intro text, active question, or voting results based on performance state (intro|life|closing) and audience_visibility settings. Real-time synchronized. Full-width black background via `CenteredContainer`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 **Questions**
 - `id`, `name`, `question`, `type` (text|player-pick|voting|match|options|info|select)
 - `performance_id`: Links to performance
-- `state` (draft|active|locked|answered): Controls visibility
+- `state` (hidden|active|locked): Controls visibility
 - `audience_visibility` (hidden|question|results): Controls audience display
 - `pool_id`: Optional grouping in voting pools
 - `index_order`: Display order
@@ -273,10 +273,9 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### Three-Layer Visibility System
 
 **Question State** (controls answering):
-- `draft`: Not shown to anyone
+- `hidden`: Not shown to anyone (default for new questions; also where played questions end up)
 - `active`: Users can answer; admin can see answers
 - `locked`: No more answers accepted; admin reviews
-- `answered`: Results shown; no new answers
 
 **Audience Visibility** (controls audience display):
 - `hidden`: Not visible to audience
@@ -291,8 +290,8 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### State Transitions
 
 **Admin Controls**:
-- `setQuestionState()`: Admin moves question through draft→active→locked→answered
-  - When setting new state, auto-hides all other active questions
+- `setQuestionState()`: Admin moves question through hidden→active→locked
+  - When setting new state, auto-hides all other active/locked questions (back to `hidden`)
 - `setAudienceVisibility()`: Admin controls what audience sees
   - Setting visibility hides all other visible questions and pools
 - `setPoolAudienceVisibility()`: Toggle pool visibility

--- a/api/questions.api.ts
+++ b/api/questions.api.ts
@@ -96,7 +96,7 @@ export const fetchQuestion = async (questionId: number): Promise<QuestionDetailR
 export const fetchQuestionState = async (questionId: number): Promise<QuestionState> => {
     const supabase = await createClient();
     const response = await supabase.from("questions").select("state").eq("id", questionId).single();
-    return response.data?.state ?? "draft";
+    return response.data?.state ?? "hidden";
 };
 
 export const fetchQuestions = async (performanceId: number): Promise<QuestionsResponse> => {
@@ -154,7 +154,7 @@ export const fetchQuestionOptions = async (questionId: number): Promise<Question
 export const setQuestionState = async (questionId: number, state: QuestionState): Promise<QuestionResponse> => {
     const supabase = await createClient();
     // first, hide all visible
-    await supabase.from("questions").update({ state: "answered" }).in("state", ["active", "locked"]);
+    await supabase.from("questions").update({ state: "hidden" }).in("state", ["active", "locked"]);
 
     const response = await supabase.from("questions").update({ state }).eq("id", questionId).select().single();
     const performanceId = response.data?.performance_id;
@@ -195,7 +195,7 @@ export const createQuestion = async (performanceId: number, question: QuestionUp
         .from("questions")
         .insert({
             ...questionData,
-            state: "draft",
+            state: "hidden",
             performance_id: performanceId,
         })
         .select();
@@ -412,12 +412,12 @@ export const fetchFirstQuestionInChain = async (questionId: number): Promise<num
 
 export const hideAllForQuestion = async (questionId: number, performanceId: number) => {
     const supabase = await createClient();
-    await supabase.from("questions").update({ audience_visibility: "hidden", state: "answered" }).eq("id", questionId);
+    await supabase.from("questions").update({ audience_visibility: "hidden", state: "hidden" }).eq("id", questionId);
     revalidatePath(`/admin/performances/${performanceId}`);
 };
 
 export const hideAllQuestionsForPerformance = async (performanceId: number) => {
     const supabase = await createClient();
-    await supabase.from("questions").update({ audience_visibility: "hidden", state: "answered" }).eq("performance_id", performanceId);
+    await supabase.from("questions").update({ audience_visibility: "hidden", state: "hidden" }).eq("performance_id", performanceId);
     revalidatePath(`/admin/performances/${performanceId}`);
 };

--- a/components/admin/questions/QuestionItem.tsx
+++ b/components/admin/questions/QuestionItem.tsx
@@ -20,8 +20,7 @@ export const QuestionItem = (props: Props) => {
 
     let stateIcon: ReactNode | null = null;
     switch (state) {
-        case "draft":
-        case "answered":
+        case "hidden":
             stateIcon = <EyeOff />;
             break;
         case "active":

--- a/components/admin/questions/QuestionUserStateToggle.tsx
+++ b/components/admin/questions/QuestionUserStateToggle.tsx
@@ -26,17 +26,14 @@ export const QuestionUserStateToggle = ({ question, defaultState }: Props) => {
             variant={"outline"}
             onValueChange={(newValue) => handleStateChange(newValue as QuestionState)}
         >
-            <ToggleGroupItem value="draft" title={"Skrytá otázka"}>
-                Příprava
+            <ToggleGroupItem value="hidden" title={"Skrytá otázka"}>
+                Skrýt
             </ToggleGroupItem>
             <ToggleGroupItem value="active" title={"Aktivní otázka"}>
                 <strong>VYPLŇOVÁNÍ</strong>
             </ToggleGroupItem>
             <ToggleGroupItem value="locked" title={"Aktivní otázka bez možnosti hlasovat"}>
                 Výsledky
-            </ToggleGroupItem>
-            <ToggleGroupItem value="answered" title={"Zobrazená otázka"}>
-                Hotovo
             </ToggleGroupItem>
         </ToggleGroup>
     );

--- a/utils/supabase/entity.types.ts
+++ b/utils/supabase/entity.types.ts
@@ -460,7 +460,7 @@ export type Database = {
     Enums: {
       audience_visibility: "hidden" | "question" | "results"
       "performance-state": "draft" | "intro" | "life" | "finished" | "closing"
-      "question-state": "draft" | "active" | "locked" | "answered"
+      "question-state": "hidden" | "active" | "locked"
       "question-type":
         | "text"
         | "player-pick"
@@ -598,7 +598,7 @@ export const Constants = {
     Enums: {
       audience_visibility: ["hidden", "question", "results"],
       "performance-state": ["draft", "intro", "life", "finished", "closing"],
-      "question-state": ["draft", "active", "locked", "answered"],
+      "question-state": ["hidden", "active", "locked"],
       "question-type": [
         "text",
         "player-pick",


### PR DESCRIPTION
Removes the redundant `answered` question state (functionally identical to `draft` — both hidden, no submissions, same icon) and renames `draft` → `hidden` so the state names describe actual audience/submission behavior. The state machine is now `hidden → active → locked`; played questions land in `hidden`, and the admin toggle's first button is relabeled `Skrýt`. Updates `setQuestionState`, `hideAllForQuestion`, `hideAllQuestionsForPerformance`, `createQuestion`, the admin UI, and docs.

**DB migration required before deploy:** an SQL migration must remap existing `answered` rows and recreate the `question-state` enum (Postgres can't drop an enum value in place); `entity.types.ts` is hand-edited as a stopgap until `pnpm run types:gen` is re-run post-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)