### PR TITLE
fix: preload LCP performance cover image

### DIFF
--- a/components/ui/PerformanceList.tsx
+++ b/components/ui/PerformanceList.tsx
@@ -13,7 +13,7 @@ interface PerformanceListProps {
 export function PerformanceList({ performances }: PerformanceListProps) {
     return (
         <div className="flex flex-col gap-5 px-4">
-            {performances.map((performance) => (
+            {performances.map((performance, index) => (
                 <div key={performance.id} className="overflow-hidden rounded-[14px] border bg-card">
                     <Link href={performance.link} target="_blank">
                         <Image
@@ -23,6 +23,7 @@ export function PerformanceList({ performances }: PerformanceListProps) {
                             unoptimized={true}
                             alt={performance.title}
                             className="aspect-[16/5] w-full object-cover"
+                            priority={index === 0}
                         />
                     </Link>
                     <div className="p-4 pt-3.5">


### PR DESCRIPTION
Adds `priority={index === 0}` to the first performance cover image in `PerformanceList`, which causes Next.js to emit a `<link rel="preload">` and set `loading="eager"` automatically. This eliminates the browser warning about the LCP image being lazy-loaded.