### PR TITLE
feat(admin): player management section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 ## App Routes Structure
 
 ### Admin Routes (`/admin/*`)
+
 - **`/admin`**: Performances list (server component, requires auth)
 - **`/admin/performances/[performanceId]`**: Performance detail and question management
 - **`/admin/performances/[performanceId]/add-question`**: Create new question form
@@ -24,27 +25,32 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 - **`/admin/questions/[questionId]/view`**: View question and manage answers
 
 **Key Patterns**:
+
 - Server components for data fetching and auth enforcement
 - Uses `revalidatePath()` for ISR (Incremental Static Regeneration)
 - Direct Supabase queries via server actions
 
 ### Audience Routes (`/audience/*`)
+
 - **`/audience`**: Main audience view (server-rendered, fetches active performance)
-  - Routes based on performance state: `intro` → `life` → `closing`
-  - Shows intro, question detail, or upcoming performances
+    - Routes based on performance state: `intro` → `life` → `closing`
+    - Shows intro, question detail, or upcoming performances
 - **Layout**: Full-width black background container
 - **Real-time Updates**: Subscribed to performance state changes
 
 ### User/Question Routes (`/question/[questionId]`)
+
 - **`/question/[questionId]`**: Client component, loads question via hook
-  - Uses `useQuestion()` hook for fetching and real-time sync
-  - Renders different question type components dynamically
+    - Uses `useQuestion()` hook for fetching and real-time sync
+    - Renders different question type components dynamically
 
 ### Auth Routes (`/auth/*`)
+
 - **`/auth/user`**: GET endpoint that generates/returns anonymous user ID (UUID stored in cookie)
 - **`/auth/callback`**: OAuth callback handler (Supabase auth flow)
 
 ### Login Routes (`/login`)
+
 - Supabase OAuth login flow
 
 ## Database Schema & Entity Types
@@ -52,12 +58,14 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 ### Core Entities
 
 **Performances**
+
 - `id`, `name`, `date`, `state` (draft|intro|life|finished|closing)
 - `intro_text`: HTML for intro screen
 - `url_slug`: URL identifier
 - Junction: `performances_players` (many-to-many with players)
 
 **Questions**
+
 - `id`, `name`, `question`, `type` (text|player-pick|voting|match|options|info|select)
 - `performance_id`: Links to performance
 - `state` (hidden|active|locked): Controls visibility
@@ -69,6 +77,7 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 - Junction: `questions_players` (many-to-many with players)
 
 **Answers** (Multiple tables by type):
+
 - `answers_text`: Open-ended responses with optional `favorite` and `drawn` fields
 - `answers_vote`: Voting answers linking user to player choice
 - `answers_match`: Matching answers (character-to-player)
@@ -76,6 +85,7 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 - All include `user_id` (anonymous UUID), `question_id`
 
 **Supporting Entities**:
+
 - `characters`: Optional character list for matching questions
 - `questions_options`: Multiple choice options
 - `questions_pool`: Grouped voting questions (with `audience_visibility` boolean)
@@ -84,10 +94,12 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 ### Type System Organization
 
 **File**: `/utils/supabase/entity.types.ts`
+
 - Supabase auto-generated types via `types:gen` script
 - Exports: `Database`, `Tables<>`, `TablesInsert<>`, `TablesUpdate<>`, `Enums<>`
 
 **File**: `/api/types.api.ts`
+
 - Type aliases: `type Answer = ...`, `type Question = Tables<"questions">`
 - Complex types: `QuestionDetail`, `QuestionWithPlayersAndCharacters`, `PlayerWithPhotos`
 - Answer insert types (omit `user_id`): `TextAnswerInsert`, `VoteAnswerInsert`, etc.
@@ -98,63 +110,73 @@ A Next.js 14 application for managing interactive question-and-answer sessions d
 All API calls are **server actions** (marked with `"use server"`), organized by domain:
 
 ### `/api/questions.api.ts`
+
 - **Fetch**: `fetchQuestion()`, `fetchQuestions()`, `fetchQuestionPlayers()`, `fetchQuestionCharacters()`, `fetchQuestionOptions()`, `fetchActiveOrLockedQuestion()`, `findQuestion()`
 - **Mutate**: `createQuestion()`, `updateQuestion()`, `setQuestionState()`, `setAudienceVisibility()`, `hideAllForQuestion()`, `getNewIndexOrder()`
 - **Pattern**: Uses React's `cache()` for deduplication within request
 - **Revalidation**: Calls `revalidatePath()` on mutations to invalidate ISR
 
 ### `/api/answers.api.ts`
+
 - **Fetch**: `fetchTextAnswers()`, `fetchVoteAnswers()`, `fetchMatchingAnswers()`, `fetchOptionsAnswers()`, `fetchPoolVoteAnswers()`, `fetchMatchingQuestionResults()` (RPC call)
 - **Mutate**: `removeTextAnswers()`, `favoriteTextAnswer()`, `randomDrawAnswer()`
 - **Pattern**: Generic `useAnswers<T>()` hook pattern (see below)
 
 ### `/api/submit-answer.ts`
+
 - **Mutate**: `submitTextAnswer()`, `submitVoteAnswer()`, `submitMatchAnswer()`, `submitOptionsAnswer()`
 - **Validation**: `submitVoteAnswer()` validates question state before accepting
 - **Pattern**: Extracts `user_id` from cookie, throws if missing
 
 ### `/api/performances.api.ts`
+
 - **Fetch**: `fetchPerformances()`, `fetchPerformance()`, `fetchVisiblePerformance()`, `fetchAvailablePlayers()`
 - **Mutate**: `setPerformanceState()`
 - **Note**: `fetchVisiblePerformance()` filters by state in (intro|life|closing)
 
 ### `/api/question-pools.api.ts`
+
 - **Fetch**: `fetchAvailablePools()`, `fetchQuestionPool()`, `fetchVisiblePool()`
 - **Mutate**: `setPoolAudienceVisibility()` (hides other pools and questions)
 
 ### `/api/web.api.ts`
+
 - **Integrates**: External WordPress API (improvariace.cz)
 - **Export**: `getUpcomingPerformances()` - fetches performances with venues, media, CTAs
 - **Caching**: Next.js `revalidate: 3600` for 1-hour cache
 
 ### `/api/photos.api.ts`
+
 - Stubbed API for fetching player photos
 
 ## State Management - Zustand Stores
 
 ### `/store/admin.store.ts`
+
 - **State**:
-  - `answers: Answer[]` - Answers for current question
-  - `loading: boolean`
+    - `answers: Answer[]` - Answers for current question
+    - `loading: boolean`
 - **Mutations**: `setAnswers()`, `addAnswer()`, `modifyAnswer()`, `removeAnswer()`, `removeAnswers()`
 - **Used By**: Admin answer display components with real-time subscriptions
 
 ### `/store/audience.store.ts`
+
 - **State**:
-  - `question: Question | null`
-  - `pool: QuestionPool | null`
-  - `loading: boolean`
+    - `question: Question | null`
+    - `pool: QuestionPool | null`
+    - `loading: boolean`
 - **Mutations**: `setQuestion()`, `setPool()`, `setLoading()`
 - **Used By**: Audience-facing components
 
 ### `/store/users.store.ts` (Persisted)
+
 - **State**:
-  - `userId?: string` - Anonymous UUID
-  - `question: Question | null`
-  - `performance: Performance | null`
-  - `answeredQuestions: Record<number, boolean>` - Track answered state
-  - `answers: Record<number, string | number>` - Cached user answers
-  - `onboarding: { completed, currentStep }` - Onboarding progress
+    - `userId?: string` - Anonymous UUID
+    - `question: Question | null`
+    - `performance: Performance | null`
+    - `answeredQuestions: Record<number, boolean>` - Track answered state
+    - `answers: Record<number, string | number>` - Cached user answers
+    - `onboarding: { completed, currentStep }` - Onboarding progress
 - **Persistence**: Uses Zustand persist middleware → localStorage (`user-storage`)
 - **Used By**: User question components, AuthUser wrapper
 
@@ -167,21 +189,21 @@ All real-time subscriptions follow this pattern:
 ```typescript
 const supabase = createClient(); // Browser client
 const channel = supabase
-  .channel("unique-channel-name")
-  .on<EntityType>(
-    "postgres_changes",
-    {
-      event: "INSERT|UPDATE|DELETE",
-      schema: "public",
-      table: "table_name",
-      filter: "column=eq.value", // Optional filtering
-    },
-    (payload) => {
-      // Handle payload.new / payload.old / payload.old_image
-      updateState();
-    }
-  )
-  .subscribe();
+    .channel("unique-channel-name")
+    .on<EntityType>(
+        "postgres_changes",
+        {
+            event: "INSERT|UPDATE|DELETE",
+            schema: "public",
+            table: "table_name",
+            filter: "column=eq.value", // Optional filtering
+        },
+        (payload) => {
+            // Handle payload.new / payload.old / payload.old_image
+            updateState();
+        },
+    )
+    .subscribe();
 
 // Cleanup on unmount:
 return () => supabase.removeChannel(channel);
@@ -190,17 +212,20 @@ return () => supabase.removeChannel(channel);
 ### Subscription Channels
 
 **Admin Context** (hooks/admin.hooks.ts):
+
 - `useTextAnswers()`, `useVoteAnswers()`, `useMatchingAnswers()`, `useOptionsAnswers()`
 - **Pattern**: Generic `useAnswers<T>(table, questionId, fetcher)`
 - **Subscribes**: INSERT and UPDATE events for current question
 - **Updates**: Via `addAnswer()` and `modifyAnswer()` Zustand actions
 
 **User Context** (hooks/users.hooks.ts):
+
 - `useActiveOrLockedQuestion()`: Watches for active/locked state changes
 - `usePerformance()`: Watches for state changes (e.g., intro→life→closing)
 - **Filters**: Listens to specific performance_id updates
 
 **Audience Context** (hooks/audience.hooks.ts):
+
 - `useQuestion()`: Watches audience_visibility changes (question|results|hidden)
 - `usePool()`: Watches pool audience_visibility boolean changes
 - **Effect**: Automatically clears state when visibility changes to hidden
@@ -214,6 +239,7 @@ Real-time subscriptions require browser client (`createClient()` from `utils/sup
 ### Client Initialization
 
 **Server Context** (`utils/supabase/server.ts`):
+
 ```typescript
 export const createClient = (cookieStore) => createServerClient<Database>(..., {
   cookies: { get, set, remove } // Manages session cookies
@@ -221,6 +247,7 @@ export const createClient = (cookieStore) => createServerClient<Database>(..., {
 ```
 
 **Browser Context** (`utils/supabase/client.ts`):
+
 ```typescript
 export const createClient = () => createBrowserClient(...) // Deprecated; used only for real-time
 ```
@@ -242,6 +269,7 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ## Question Type Handling
 
 ### Question Types (Enum)
+
 - `text`: Open-ended text responses
 - `player-pick`: Match/assign to player
 - `voting`: Vote for a player
@@ -253,6 +281,7 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### Component Mapping
 
 **User Components** (`components/users/questions/`):
+
 - `TextQuestion.tsx`: Text input with submit
 - `PlayersVotingQuestion/PlayersVotingQuestion.tsx`: Vote buttons
 - `MatchQuestion/MatchQuestion.tsx`: Drag-and-drop character matching
@@ -261,6 +290,7 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 - `UserQuestionDetail.tsx`: Router (renders based on type)
 
 **Audience Components** (`components/audience/answers/`):
+
 - `TextQuestionAnswers.tsx`: Display text answers with favorite/draw
 - `PlayersVotingAnswers.tsx`: Show vote counts
 - `PoolVotingAnswers.tsx`: Voting results within question pool
@@ -273,16 +303,19 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### Three-Layer Visibility System
 
 **Question State** (controls answering):
+
 - `hidden`: Not shown to anyone (default for new questions; also where played questions end up)
 - `active`: Users can answer; admin can see answers
 - `locked`: No more answers accepted; admin reviews
 
 **Audience Visibility** (controls audience display):
+
 - `hidden`: Not visible to audience
 - `question`: Show question to audience (they can answer)
 - `results`: Show results only (voting completed)
 
 **Pool Visibility** (overrides individual questions):
+
 - `audience_visibility: boolean` on `questions_pool`
 - When pool is visible, grouped voting questions show results
 - Setting pool visible hides all individual question visibility
@@ -290,41 +323,48 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### State Transitions
 
 **Admin Controls**:
+
 - `setQuestionState()`: Admin moves question through hidden→active→locked
-  - When setting new state, auto-hides all other active/locked questions (back to `hidden`)
+    - When setting new state, auto-hides all other active/locked questions (back to `hidden`)
 - `setAudienceVisibility()`: Admin controls what audience sees
-  - Setting visibility hides all other visible questions and pools
+    - Setting visibility hides all other visible questions and pools
 - `setPoolAudienceVisibility()`: Toggle pool visibility
-  - Hides all individual questions when pool is shown
+    - Hides all individual questions when pool is shown
 
 **Audience View**:
+
 - Audience component filters questions by `audience_visibility` in (question|results)
 - Real-time subscription updates audience display when state changes
 
 ## Component Organization
 
 ### Layout Components
+
 - `/components/ui/layout/TabletContainer.tsx`: Admin layout (desktop-first)
 - `/components/ui/layout/CenteredContainer.tsx`: Audience layout (centered black background)
 - `/components/ui/layout/MobileContainer.tsx`: Mobile-responsive container
 
 ### UI Primitives
+
 - `Button`, `Input`, `Label`, `Select`, `Switch`, `Textarea`, `Badge`, `Table`
 - Drag-and-drop: `Draggable`, `Droppable` (@dnd-kit)
 - Toggle: `Toggle`, `ToggleGroup` (Radix)
 
 ### Admin Components
+
 - **Questions**: Question list, form, editing
 - **Answers**: Type-specific answer displays (text, voting, matching)
 - **Performance**: State toggle (draft→intro→life→closing)
 - **Pools**: Pool visibility management
 
 ### User Components
+
 - **Questions**: Type-specific question forms
 - **Onboarding**: Welcome/instructions flow
 - **Sharing**: QR codes and social sharing actions
 
 ### Audience Components
+
 - **Display**: Real-time question and answer rendering
 - **Index**: Router logic based on performance state
 
@@ -333,15 +373,15 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ### Current Implementation
 
 - **Anonymous Users** (audience/users): UUID-based identification (not secure)
-  - No password required
-  - Tracked via cookie + localStorage
-  - Each browser/device gets unique ID
-  - Vulnerability: Can spoof userId in requests
+    - No password required
+    - Tracked via cookie + localStorage
+    - Each browser/device gets unique ID
+    - Vulnerability: Can spoof userId in requests
 
 - **Admins** (admin routes): Supabase Auth required
-  - Email/password or OAuth
-  - Session managed via Supabase + middleware cookie refresh
-  - Check: `const user = await supabase.auth.getUser()`
+    - Email/password or OAuth
+    - Session managed via Supabase + middleware cookie refresh
+    - Check: `const user = await supabase.auth.getUser()`
 
 ### Potential Issues
 
@@ -367,9 +407,9 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 1. Admin clicks toggle on question detail page
 2. `setAudienceVisibility()` server action called
 3. Action:
-   - Sets other questions to `hidden`
-   - Sets target question to desired state
-   - Calls `revalidatePath()` to bust ISR cache
+    - Sets other questions to `hidden`
+    - Sets target question to desired state
+    - Calls `revalidatePath()` to bust ISR cache
 4. Server component re-renders with new state
 5. Audience's `useQuestion()` subscription fires UPDATE event
 6. If visibility changed to `hidden`, audience display clears via `setQuestion(null)`
@@ -395,11 +435,13 @@ export const createClient = () => createBrowserClient(...) // Deprecated; used o
 ## Development Workflow
 
 ### Type Generation
+
 ```bash
 pnpm run types:gen  # Regenerate from Supabase schema
 ```
 
 ### Environment Setup
+
 ```
 NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
@@ -407,6 +449,7 @@ SUPABASE_SERVICE_KEY=...  # Server-side only
 ```
 
 ### Common Tasks
+
 - **Add Question Type**: Create component + add enum value + update question form
 - **Add Answer Type**: Create table + api functions + admin/audience components
 - **Change Visibility Logic**: Modify `setAudienceVisibility()` + add subscription filter
@@ -435,17 +478,19 @@ SUPABASE_SERVICE_KEY=...  # Server-side only
 **Stack**: Next.js 15 + Supabase + Zustand
 
 ## Active Technologies
+
 - TypeScript (Next.js 14+) + Next.js 14 App Router, Supabase (@supabase/ssr), Zustand, Radix UI, Tailwind CSS (001-manage-performances)
 - Supabase PostgreSQL (tables: performances, players, performances_players, questions_players) (001-manage-performances)
 
 ## Recent Changes
+
 - 001-manage-performances: Admin performance management implementation
-  - Server actions: createPerformance, updatePerformance, assignPlayerToPerformance, removePlayerFromPerformance in api/performances.api.ts
-  - Components: PerformanceForm (controlled form, create/edit), PlayerAssignment (player add/remove), PerformanceList
-  - Pages: /admin/performances/new, /admin/performances/[id]/edit integrated into detail page
-  - Datetime pattern: datetime-local input with UTC storage, append ":00" for cross-browser parsing reliability
-  - Referential integrity: SQL JOIN check prevents player removal if assigned to questions, Czech error message
-  - Slug generation: auto-generates unique URL slugs with collision handling (slugify + counter: -2, -3, etc.)
-  - Loading states: useActionState isPending in forms, per-action loading (isAssigning, removingPlayerId) in PlayerAssignment
-  - Accessibility: aria-labels on interactive elements, role="alert|status", aria-live regions for messages
-  - Player display: formatPlayerName() shows "Name Surname (host)" format
+    - Server actions: createPerformance, updatePerformance, assignPlayerToPerformance, removePlayerFromPerformance in api/performances.api.ts
+    - Components: PerformanceForm (controlled form, create/edit), PlayerAssignment (player add/remove), PerformanceList
+    - Pages: /admin/performances/new, /admin/performances/[id]/edit integrated into detail page
+    - Datetime pattern: datetime-local input with UTC storage, append ":00" for cross-browser parsing reliability
+    - Referential integrity: SQL JOIN check prevents player removal if assigned to questions, Czech error message
+    - Slug generation: auto-generates unique URL slugs with collision handling (slugify + counter: -2, -3, etc.)
+    - Loading states: useActionState isPending in forms, per-action loading (isAssigning, removingPlayerId) in PlayerAssignment
+    - Accessibility: aria-labels on interactive elements, role="alert|status", aria-live regions for messages
+    - Player display: formatPlayerName() shows "Name Surname (host)" format

--- a/README.md
+++ b/README.md
@@ -21,25 +21,25 @@ This app supports the impro performance of [IMPROvariace](https://www.improvaria
 
 ### General
 
--   Vote Questions can be batched into a Question Pool.
+- Vote Questions can be batched into a Question Pool.
 
 ### As admin:
 
--   I can add a _vote-type_ Question.
--   I can manage Performance visibility.
--   I can manage Question visibility towards Users and Audience.
--   I can see users' Answers in real-time.
+- I can add a _vote-type_ Question.
+- I can manage Performance visibility.
+- I can manage Question visibility towards Users and Audience.
+- I can see users' Answers in real-time.
 
 ### As user:
 
--   I only see a Question when the admin sets its visibility.
--   I can submit an Answer to a Question.
--   I can see the results of a Question (if set by Admin).
+- I only see a Question when the admin sets its visibility.
+- I can submit an Answer to a Question.
+- I can see the results of a Question (if set by Admin).
 
 ## Current limitations
 
--   Missing CRUD operations over most of the entities (wasn't needed, Supabase's interface is used).
--   Only _vote-type_ Questions can be added via the Admin interface.
+- Missing CRUD operations over most of the entities (wasn't needed, Supabase's interface is used).
+- Only _vote-type_ Questions can be added via the Admin interface.
 
 ## Tech stack
 
@@ -55,4 +55,4 @@ The whole solution stands mainly on the following pillars:
 
 This is a standard [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). If you want to run it locally, deploy it, or customize it, follow the appropriate documentation.
 
-Database schema (possibly not up-to-date) can be found in [schema.db.sql](./schema.db.sql) file 
+Database schema (possibly not up-to-date) can be found in [schema.db.sql](./schema.db.sql) file

--- a/api/answers.api.ts
+++ b/api/answers.api.ts
@@ -85,10 +85,7 @@ export const areThereVotesForQuestion = async (questionId: number): Promise<bool
 
 export const fetchAnsweredOptionIds = async (questionId: number): Promise<number[]> => {
     const supabase = await createClient();
-    const response = await supabase
-        .from("answers_options")
-        .select("question_options_id")
-        .eq("question_id", questionId);
+    const response = await supabase.from("answers_options").select("question_options_id").eq("question_id", questionId);
     if (!response.data) return [];
     return [...new Set(response.data.map((a) => a.question_options_id))];
 };

--- a/api/performances.api.ts
+++ b/api/performances.api.ts
@@ -54,54 +54,52 @@ export const fetchAvailablePlayers = async (performanceId: number) => {
 export type Player = Tables<"players">;
 
 export type PerformanceWithPlayers = Performance & {
-  players: Player[];
+    players: Player[];
 };
 
 export type ServerActionResult<T> =
-  | { success: true; data: T }
-  | { success: false; error: string; fieldErrors?: Record<string, string[]> };
+    | { success: true; data: T }
+    | { success: false; error: string; fieldErrors?: Record<string, string[]> };
 
 // ============================================================================
 // Validation Schemas (T009)
 // ============================================================================
 
 const createPerformanceSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255, "Name too long"),
-  date: z.string().date("Invalid date format"),
-  intro_text: z.string().max(10000, "Intro text too long").optional(),
-  url_slug: z
-    .string()
-    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Invalid slug format")
-    .optional(),
-  state: z
-    .enum(["draft", "intro", "life", "finished", "closing"])
-    .default("draft"),
+    name: z.string().min(1, "Name is required").max(255, "Name too long"),
+    date: z.string().date("Invalid date format"),
+    intro_text: z.string().max(10000, "Intro text too long").optional(),
+    url_slug: z
+        .string()
+        .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Invalid slug format")
+        .optional(),
+    state: z.enum(["draft", "intro", "life", "finished", "closing"]).default("draft"),
 });
 
 const updatePerformanceSchema = z
-  .object({
-    id: z.number().int().positive(),
-    name: z.string().min(1).max(255).optional(),
-    date: z.string().date().optional(),
-    intro_text: z.string().max(10000).optional(),
-    url_slug: z
-      .string()
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
-      .optional(),
-    state: z.enum(["draft", "intro", "life", "finished", "closing"]).optional(),
-  })
-  .refine((data) => Object.keys(data).length > 1, {
-    message: "At least one field must be updated",
-  });
+    .object({
+        id: z.number().int().positive(),
+        name: z.string().min(1).max(255).optional(),
+        date: z.string().date().optional(),
+        intro_text: z.string().max(10000).optional(),
+        url_slug: z
+            .string()
+            .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+            .optional(),
+        state: z.enum(["draft", "intro", "life", "finished", "closing"]).optional(),
+    })
+    .refine((data) => Object.keys(data).length > 1, {
+        message: "At least one field must be updated",
+    });
 
 const assignPlayerSchema = z.object({
-  performance_id: z.number().int().positive(),
-  player_id: z.number().int().positive(),
+    performance_id: z.number().int().positive(),
+    player_id: z.number().int().positive(),
 });
 
 const removePlayerSchema = z.object({
-  performance_id: z.number().int().positive(),
-  player_id: z.number().int().positive(),
+    performance_id: z.number().int().positive(),
+    player_id: z.number().int().positive(),
 });
 
 // ============================================================================
@@ -111,424 +109,384 @@ const removePlayerSchema = z.object({
 // Generates URL-safe slug from performance name with uniqueness guarantee
 // If slug exists, appends -2, -3, etc. until unique (e.g., "letni-improvizace-2")
 async function generateUniqueSlug(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  baseName: string,
+    supabase: Awaited<ReturnType<typeof createClient>>,
+    baseName: string,
 ): Promise<string> {
-  const baseSlug = slugify(baseName, { lower: true, strict: true });
-  let finalSlug = baseSlug;
-  let counter = 2;
+    const baseSlug = slugify(baseName, { lower: true, strict: true });
+    let finalSlug = baseSlug;
+    let counter = 2;
 
-  // Check uniqueness in database, increment counter if collision
-  while (true) {
-    const { data } = await supabase
-      .from("performances")
-      .select("id")
-      .eq("url_slug", finalSlug)
-      .maybeSingle();
+    // Check uniqueness in database, increment counter if collision
+    while (true) {
+        const { data } = await supabase.from("performances").select("id").eq("url_slug", finalSlug).maybeSingle();
 
-    if (!data) break; // Slug is unique
-    finalSlug = `${baseSlug}-${counter++}`;
-  }
+        if (!data) break; // Slug is unique
+        finalSlug = `${baseSlug}-${counter++}`;
+    }
 
-  return finalSlug;
+    return finalSlug;
 }
 
 // ============================================================================
 // Fetch Actions with React.cache (T010, T011, T012)
 // ============================================================================
 
-export const fetchAllPerformances = cache(
-  async (): Promise<ServerActionResult<Performance[]>> => {
+export const fetchAllPerformances = cache(async (): Promise<ServerActionResult<Performance[]>> => {
     try {
-      const supabase = await createClient();
+        const supabase = await createClient();
 
-      // Auth check
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
-        return { success: false, error: "Unauthorized" };
-      }
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
 
-      const { data, error } = await supabase
-        .from("performances")
-        .select("*")
-        .order("date", { ascending: false });
+        const { data, error } = await supabase.from("performances").select("*").order("date", { ascending: false });
 
-      if (error) {
-        return { success: false, error: error.message };
-      }
+        if (error) {
+            return { success: false, error: error.message };
+        }
 
-      return { success: true, data: data || [] };
+        return { success: true, data: data || [] };
     } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      };
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+        };
     }
-  },
-);
+});
 
 export const fetchPerformanceWithPlayers = cache(
-  async (id: number): Promise<ServerActionResult<PerformanceWithPlayers>> => {
-    try {
-      const supabase = await createClient();
+    async (id: number): Promise<ServerActionResult<PerformanceWithPlayers>> => {
+        try {
+            const supabase = await createClient();
 
-      // Auth check
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
-        return { success: false, error: "Unauthorized" };
-      }
+            // Auth check
+            const {
+                data: { user },
+            } = await supabase.auth.getUser();
+            if (!user) {
+                return { success: false, error: "Unauthorized" };
+            }
 
-      const { data, error } = await supabase
-        .from("performances")
-        .select(
-          `
+            const { data, error } = await supabase
+                .from("performances")
+                .select(
+                    `
           *,
           performances_players(
             player:players(*)
           )
         `,
-        )
-        .eq("id", id)
-        .single();
+                )
+                .eq("id", id)
+                .single();
 
-      if (error) {
-        return { success: false, error: error.message };
-      }
+            if (error) {
+                return { success: false, error: error.message };
+            }
 
-      if (!data) {
-        return { success: false, error: "Performance not found" };
-      }
+            if (!data) {
+                return { success: false, error: "Performance not found" };
+            }
 
-      // Transform the nested structure to flat players array
-      const players =
-        data.performances_players?.map((pp: any) => pp.player).filter(Boolean) ||
-        [];
+            // Transform the nested structure to flat players array
+            const players = data.performances_players?.map((pp: any) => pp.player).filter(Boolean) || [];
 
-      const performance: PerformanceWithPlayers = {
-        ...data,
-        players,
-      };
+            const performance: PerformanceWithPlayers = {
+                ...data,
+                players,
+            };
 
-      return { success: true, data: performance };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      };
-    }
-  },
+            return { success: true, data: performance };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : "Unknown error",
+            };
+        }
+    },
 );
 
-export const fetchAllPlayers = cache(
-  async (): Promise<ServerActionResult<Player[]>> => {
+export const fetchAllPlayers = cache(async (): Promise<ServerActionResult<Player[]>> => {
     try {
-      const supabase = await createClient();
+        const supabase = await createClient();
 
-      // Auth check
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
-        return { success: false, error: "Unauthorized" };
-      }
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
 
-      const { data, error } = await supabase
-        .from("players")
-        .select("*")
-        .order("name", { ascending: true });
+        const { data, error } = await supabase.from("players").select("*").order("name", { ascending: true });
 
-      if (error) {
-        return { success: false, error: error.message };
-      }
+        if (error) {
+            return { success: false, error: error.message };
+        }
 
-      return { success: true, data: data || [] };
+        return { success: true, data: data || [] };
     } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      };
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+        };
     }
-  },
-);
+});
 
 // ============================================================================
 // Mutation Actions (Placeholders - will be implemented in Phase 3+)
 // ============================================================================
 
 export async function createPerformance(
-  input: z.infer<typeof createPerformanceSchema>,
+    input: z.infer<typeof createPerformanceSchema>,
 ): Promise<ServerActionResult<Performance>> {
-  try {
-    const supabase = await createClient();
+    try {
+        const supabase = await createClient();
 
-    // Auth check
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
+
+        // Validate input
+        const validation = createPerformanceSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Validation failed",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
+
+        const validatedInput = validation.data;
+
+        // Generate slug if not provided
+        const url_slug = validatedInput.url_slug || (await generateUniqueSlug(supabase, validatedInput.name));
+
+        // Create performance
+        const { data, error } = await supabase
+            .from("performances")
+            .insert({
+                name: validatedInput.name,
+                date: validatedInput.date,
+                intro_text: validatedInput.intro_text || "",
+                url_slug,
+                state: validatedInput.state || "draft",
+            })
+            .select()
+            .single();
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        // Revalidate admin pages
+        revalidatePath("/admin");
+
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+        };
     }
-
-    // Validate input
-    const validation = createPerformanceSchema.safeParse(input);
-    if (!validation.success) {
-      return {
-        success: false,
-        error: "Validation failed",
-        fieldErrors: validation.error.flatten().fieldErrors as Record<
-          string,
-          string[]
-        >,
-      };
-    }
-
-    const validatedInput = validation.data;
-
-    // Generate slug if not provided
-    const url_slug =
-      validatedInput.url_slug ||
-      (await generateUniqueSlug(supabase, validatedInput.name));
-
-    // Create performance
-    const { data, error } = await supabase
-      .from("performances")
-      .insert({
-        name: validatedInput.name,
-        date: validatedInput.date,
-        intro_text: validatedInput.intro_text || "",
-        url_slug,
-        state: validatedInput.state || "draft",
-      })
-      .select()
-      .single();
-
-    if (error) {
-      return { success: false, error: error.message };
-    }
-
-    // Revalidate admin pages
-    revalidatePath("/admin");
-
-    return { success: true, data };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
 }
 
 export async function updatePerformance(
-  input: z.infer<typeof updatePerformanceSchema>,
+    input: z.infer<typeof updatePerformanceSchema>,
 ): Promise<ServerActionResult<Performance>> {
-  try {
-    const supabase = await createClient();
+    try {
+        const supabase = await createClient();
 
-    // Auth check
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
-    }
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
 
-    // Validate input
-    const validation = updatePerformanceSchema.safeParse(input);
-    if (!validation.success) {
-      return {
-        success: false,
-        error: "Validation failed",
-        fieldErrors: validation.error.flatten().fieldErrors as Record<
-          string,
-          string[]
-        >,
-      };
-    }
+        // Validate input
+        const validation = updatePerformanceSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Validation failed",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
 
-    const validatedInput = validation.data;
-    const { id, ...updateData } = validatedInput;
+        const validatedInput = validation.data;
+        const { id, ...updateData } = validatedInput;
 
-    // Check if slug uniqueness if being updated
-    if (updateData.url_slug) {
-      const { data: existing } = await supabase
-        .from("performances")
-        .select("id")
-        .eq("url_slug", updateData.url_slug)
-        .neq("id", id)
-        .maybeSingle();
+        // Check if slug uniqueness if being updated
+        if (updateData.url_slug) {
+            const { data: existing } = await supabase
+                .from("performances")
+                .select("id")
+                .eq("url_slug", updateData.url_slug)
+                .neq("id", id)
+                .maybeSingle();
 
-      if (existing) {
+            if (existing) {
+                return {
+                    success: false,
+                    error: "URL slug already exists",
+                    fieldErrors: { url_slug: ["Tato URL adresa již existuje"] },
+                };
+            }
+        }
+
+        // Update performance
+        const { data, error } = await supabase.from("performances").update(updateData).eq("id", id).select().single();
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        if (!data) {
+            return { success: false, error: "Performance not found" };
+        }
+
+        // Revalidate admin pages
+        revalidatePath("/admin");
+        revalidatePath(`/admin/performances/${id}`);
+
+        return { success: true, data };
+    } catch (error) {
         return {
-          success: false,
-          error: "URL slug already exists",
-          fieldErrors: { url_slug: ["Tato URL adresa již existuje"] },
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
         };
-      }
     }
-
-    // Update performance
-    const { data, error } = await supabase
-      .from("performances")
-      .update(updateData)
-      .eq("id", id)
-      .select()
-      .single();
-
-    if (error) {
-      return { success: false, error: error.message };
-    }
-
-    if (!data) {
-      return { success: false, error: "Performance not found" };
-    }
-
-    // Revalidate admin pages
-    revalidatePath("/admin");
-    revalidatePath(`/admin/performances/${id}`);
-
-    return { success: true, data };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
 }
 
 export async function assignPlayerToPerformance(
-  input: z.infer<typeof assignPlayerSchema>,
+    input: z.infer<typeof assignPlayerSchema>,
 ): Promise<ServerActionResult<void>> {
-  try {
-    const supabase = await createClient();
+    try {
+        const supabase = await createClient();
 
-    // Auth check
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
-    }
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
 
-    // Validate input
-    const validation = assignPlayerSchema.safeParse(input);
-    if (!validation.success) {
-      return {
-        success: false,
-        error: "Validation failed",
-        fieldErrors: validation.error.flatten().fieldErrors as Record<
-          string,
-          string[]
-        >,
-      };
-    }
+        // Validate input
+        const validation = assignPlayerSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Validation failed",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
 
-    const { performance_id, player_id } = validation.data;
+        const { performance_id, player_id } = validation.data;
 
-    // Insert with ON CONFLICT DO NOTHING (duplicate check)
-    const { error } = await supabase
-      .from("performances_players")
-      .insert({ performance_id, player_id })
-      .select();
+        // Insert with ON CONFLICT DO NOTHING (duplicate check)
+        const { error } = await supabase.from("performances_players").insert({ performance_id, player_id }).select();
 
-    if (error) {
-      // Check if duplicate error
-      if (error.code === "23505") {
+        if (error) {
+            // Check if duplicate error
+            if (error.code === "23505") {
+                return {
+                    success: false,
+                    error: "Player already assigned to this performance",
+                };
+            }
+            return { success: false, error: error.message };
+        }
+
+        // Revalidate performance detail page
+        revalidatePath(`/admin/performances/${performance_id}`);
+
+        return { success: true, data: undefined };
+    } catch (error) {
         return {
-          success: false,
-          error: "Player already assigned to this performance",
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
         };
-      }
-      return { success: false, error: error.message };
     }
-
-    // Revalidate performance detail page
-    revalidatePath(`/admin/performances/${performance_id}`);
-
-    return { success: true, data: undefined };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
 }
 
 export async function removePlayerFromPerformance(
-  input: z.infer<typeof removePlayerSchema>,
+    input: z.infer<typeof removePlayerSchema>,
 ): Promise<ServerActionResult<void>> {
-  try {
-    const supabase = await createClient();
+    try {
+        const supabase = await createClient();
 
-    // Auth check
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
+        // Auth check
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
+
+        // Validate input
+        const validation = removePlayerSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Validation failed",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
+
+        const { performance_id, player_id } = validation.data;
+
+        // Referential integrity check: prevent removing player if assigned to any questions
+        // Uses JOIN to fetch all questions the player is assigned to via questions_players
+        const { data: questionsData, error: checkError } = await supabase
+            .from("questions_players")
+            .select("question:questions!inner(performance_id)")
+            .eq("player_id", player_id);
+
+        if (checkError) {
+            return { success: false, error: checkError.message };
+        }
+
+        // Filter to check if player is assigned to questions in THIS performance
+        const hasQuestions = questionsData?.some((qp: any) => qp.question?.performance_id === performance_id);
+
+        if (hasQuestions) {
+            // Return Czech error message as specified in requirements
+            return {
+                success: false,
+                error: "Improvizátor nemůže být odstraněn, protože je přiřazen k otázce.",
+            };
+        }
+
+        // Safe to delete
+        const { error } = await supabase
+            .from("performances_players")
+            .delete()
+            .eq("performance_id", performance_id)
+            .eq("player_id", player_id);
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        // Revalidate performance detail page
+        revalidatePath(`/admin/performances/${performance_id}`);
+
+        return { success: true, data: undefined };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+        };
     }
-
-    // Validate input
-    const validation = removePlayerSchema.safeParse(input);
-    if (!validation.success) {
-      return {
-        success: false,
-        error: "Validation failed",
-        fieldErrors: validation.error.flatten().fieldErrors as Record<
-          string,
-          string[]
-        >,
-      };
-    }
-
-    const { performance_id, player_id } = validation.data;
-
-    // Referential integrity check: prevent removing player if assigned to any questions
-    // Uses JOIN to fetch all questions the player is assigned to via questions_players
-    const { data: questionsData, error: checkError } = await supabase
-      .from("questions_players")
-      .select("question:questions!inner(performance_id)")
-      .eq("player_id", player_id);
-
-    if (checkError) {
-      return { success: false, error: checkError.message };
-    }
-
-    // Filter to check if player is assigned to questions in THIS performance
-    const hasQuestions = questionsData?.some(
-      (qp: any) => qp.question?.performance_id === performance_id,
-    );
-
-    if (hasQuestions) {
-      // Return Czech error message as specified in requirements
-      return {
-        success: false,
-        error: "Improvizátor nemůže být odstraněn, protože je přiřazen k otázce.",
-      };
-    }
-
-    // Safe to delete
-    const { error } = await supabase
-      .from("performances_players")
-      .delete()
-      .eq("performance_id", performance_id)
-      .eq("player_id", player_id);
-
-    if (error) {
-      return { success: false, error: error.message };
-    }
-
-    // Revalidate performance detail page
-    revalidatePath(`/admin/performances/${performance_id}`);
-
-    return { success: true, data: undefined };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
 }

--- a/api/performances.api.ts
+++ b/api/performances.api.ts
@@ -506,7 +506,7 @@ export async function removePlayerFromPerformance(
       // Return Czech error message as specified in requirements
       return {
         success: false,
-        error: "Hráč nemůže být odstraněn, protože je přiřazen k otázce.",
+        error: "Improvizátor nemůže být odstraněn, protože je přiřazen k otázce.",
       };
     }
 

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -132,3 +132,39 @@ export async function updatePlayer(input: {
         return { success: false, error: error instanceof Error ? error.message : "Neznámá chyba" };
     }
 }
+
+export async function uploadPlayerPhoto(
+    playerId: number,
+    kind: "profile" | "body",
+    formData: FormData,
+): Promise<ServerActionResult<null>> {
+    try {
+        const supabase = await createClient();
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
+
+        const file = formData.get("photo") as File;
+        if (!file || file.size === 0) {
+            return { success: false, error: "Žádný soubor nebyl vybrán" };
+        }
+
+        const path = `${playerId}-${kind}.jpg`;
+        const { error } = await supabase.storage.from("photos").upload(path, file, {
+            upsert: true,
+            contentType: "image/jpeg",
+        });
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        revalidatePath(`/admin/players/${playerId}/edit`);
+        return { success: true, data: null };
+    } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : "Neznámá chyba" };
+    }
+}

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -1,0 +1,23 @@
+"use server";
+import { revalidatePath } from "next/cache";
+
+import type { Player, ServerActionResult } from "@/api/types.api";
+import { createClient } from "@/utils/supabase/server";
+
+export const fetchPlayers = async (): Promise<ServerActionResult<Player[]>> => {
+    const supabase = await createClient();
+    const { data, error } = await supabase.from("players").select("*").order("name");
+    if (error) {
+        return { success: false, error: error.message };
+    }
+    return { success: true, data: data ?? [] };
+};
+
+export const fetchPlayer = async (id: number): Promise<ServerActionResult<Player>> => {
+    const supabase = await createClient();
+    const { data, error } = await supabase.from("players").select("*").eq("id", id).single();
+    if (error) {
+        return { success: false, error: error.message };
+    }
+    return { success: true, data };
+};

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -115,12 +115,7 @@ export async function updatePlayer(input: {
         }
 
         const { id, ...updateData } = validation.data;
-        const { data, error } = await supabase
-            .from("players")
-            .update(updateData)
-            .eq("id", id)
-            .select()
-            .single();
+        const { data, error } = await supabase.from("players").update(updateData).eq("id", id).select().single();
 
         if (error) {
             return { success: false, error: error.message };
@@ -145,9 +140,7 @@ export const fetchPlayerPerformances = async (playerId: number): Promise<ServerA
         return { success: false, error: error.message };
     }
 
-    const performances = (data ?? [])
-        .map((row: any) => row.performance)
-        .filter(Boolean) as Performance[];
+    const performances = (data ?? []).map((row: any) => row.performance).filter(Boolean) as Performance[];
 
     performances.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -1,5 +1,6 @@
 "use server";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 
 import type { Player, ServerActionResult } from "@/api/types.api";
 import { createClient } from "@/utils/supabase/server";
@@ -21,3 +22,113 @@ export const fetchPlayer = async (id: number): Promise<ServerActionResult<Player
     }
     return { success: true, data };
 };
+
+// ============================================================================
+// Validation schemas
+// ============================================================================
+
+const createPlayerSchema = z.object({
+    name: z.string().min(1, "Jméno je povinné").max(255),
+    surname: z.string().max(255).optional(),
+    motto: z.string().max(500).optional(),
+    quest: z.boolean().default(false),
+});
+
+const updatePlayerSchema = z.object({
+    id: z.number().int().positive(),
+    name: z.string().min(1, "Jméno je povinné").max(255).optional(),
+    surname: z.string().max(255).optional().nullable(),
+    motto: z.string().max(500).optional().nullable(),
+    quest: z.boolean().optional(),
+});
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+export async function createPlayer(input: {
+    name: string;
+    surname?: string;
+    motto?: string;
+    quest: boolean;
+}): Promise<ServerActionResult<Player>> {
+    try {
+        const supabase = await createClient();
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
+
+        const validation = createPlayerSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Chyba validace",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
+
+        const { name, surname, motto, quest } = validation.data;
+        const { data, error } = await supabase
+            .from("players")
+            .insert({ name, surname: surname || null, motto: motto || null, quest })
+            .select()
+            .single();
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        revalidatePath("/admin/players");
+        return { success: true, data };
+    } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : "Neznámá chyba" };
+    }
+}
+
+export async function updatePlayer(input: {
+    id: number;
+    name?: string;
+    surname?: string | null;
+    motto?: string | null;
+    quest?: boolean;
+}): Promise<ServerActionResult<Player>> {
+    try {
+        const supabase = await createClient();
+        const {
+            data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+            return { success: false, error: "Unauthorized" };
+        }
+
+        const validation = updatePlayerSchema.safeParse(input);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: "Chyba validace",
+                fieldErrors: validation.error.flatten().fieldErrors as Record<string, string[]>,
+            };
+        }
+
+        const { id, ...updateData } = validation.data;
+        const { data, error } = await supabase
+            .from("players")
+            .update(updateData)
+            .eq("id", id)
+            .select()
+            .single();
+
+        if (error) {
+            return { success: false, error: error.message };
+        }
+
+        revalidatePath("/admin/players");
+        revalidatePath(`/admin/players/${id}/edit`);
+        return { success: true, data };
+    } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : "Neznámá chyba" };
+    }
+}

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -2,7 +2,7 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
-import type { Player, ServerActionResult } from "@/api/types.api";
+import type { Performance, Player, ServerActionResult } from "@/api/types.api";
 import { createClient } from "@/utils/supabase/server";
 
 export const fetchPlayers = async (): Promise<ServerActionResult<Player[]>> => {
@@ -132,6 +132,26 @@ export async function updatePlayer(input: {
         return { success: false, error: error instanceof Error ? error.message : "Neznámá chyba" };
     }
 }
+
+export const fetchPlayerPerformances = async (playerId: number): Promise<ServerActionResult<Performance[]>> => {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+        .from("performances_players")
+        .select("performance:performances(*)")
+        .eq("player_id", playerId);
+
+    if (error) {
+        return { success: false, error: error.message };
+    }
+
+    const performances = (data ?? [])
+        .map((row: any) => row.performance)
+        .filter(Boolean) as Performance[];
+
+    performances.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+    return { success: true, data: performances };
+};
 
 export async function uploadPlayerPhoto(
     playerId: number,

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { Performance, Player, ServerActionResult } from "@/api/types.api";
 import { createClient } from "@/utils/supabase/server";
+import { createServiceClient } from "@/utils/supabase/service";
 
 export const fetchPlayers = async (): Promise<ServerActionResult<Player[]>> => {
     const supabase = await createClient();
@@ -173,7 +174,8 @@ export async function uploadPlayerPhoto(
         }
 
         const path = `${playerId}-${kind}.jpg`;
-        const { error } = await supabase.storage.from("photos").upload(path, file, {
+        const serviceClient = createServiceClient();
+        const { error } = await serviceClient.storage.from("photos").upload(path, file, {
             upsert: true,
             contentType: "image/jpeg",
         });

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -169,11 +169,10 @@ export async function uploadPlayerPhoto(
         const path = `${playerId}-${kind}.jpg`;
         const serviceClient = createServiceClient();
 
-        await serviceClient.storage.from("photos").remove([path]);
-
         const { error } = await serviceClient.storage.from("photos").upload(path, file, {
             contentType: "image/jpeg",
-            cacheControl: "3600",
+            cacheControl: "0",
+            upsert: true,
         });
 
         if (error) {

--- a/api/players.api.ts
+++ b/api/players.api.ts
@@ -175,9 +175,12 @@ export async function uploadPlayerPhoto(
 
         const path = `${playerId}-${kind}.jpg`;
         const serviceClient = createServiceClient();
+
+        await serviceClient.storage.from("photos").remove([path]);
+
         const { error } = await serviceClient.storage.from("photos").upload(path, file, {
-            upsert: true,
             contentType: "image/jpeg",
+            cacheControl: "3600",
         });
 
         if (error) {

--- a/api/questions.api.ts
+++ b/api/questions.api.ts
@@ -133,10 +133,7 @@ export const fetchQuestionCharacters = async (questionId: number): Promise<Chara
 
 export const fetchAnsweredCharacterIds = async (questionId: number): Promise<number[]> => {
     const supabase = await createClient();
-    const response = await supabase
-        .from("answers_match")
-        .select("character_id")
-        .eq("question_id", questionId);
+    const response = await supabase.from("answers_match").select("character_id").eq("question_id", questionId);
     if (!response.data) return [];
     return [...new Set(response.data.map((a) => a.character_id))];
 };
@@ -260,10 +257,7 @@ export const updateQuestion = async (questionId: number, question: QuestionUpser
 
     // sync characters for match questions
     if (characters !== undefined) {
-        const existingChars = await supabase
-            .from("characters")
-            .select("id")
-            .eq("question_id", questionId);
+        const existingChars = await supabase.from("characters").select("id").eq("question_id", questionId);
         const existingIds = new Set((existingChars.data ?? []).map((c) => c.id));
         const submittedIds = new Set(characters.filter((c) => c.id !== undefined).map((c) => c.id!));
 
@@ -395,11 +389,7 @@ export const fetchFirstQuestionInChain = async (questionId: number): Promise<num
 
     if (!foundPredecessor) {
         // Check if this question itself has a following_question_id (i.e., it's the start of a chain)
-        const { data } = await supabase
-            .from("questions")
-            .select("following_question_id")
-            .eq("id", questionId)
-            .single();
+        const { data } = await supabase.from("questions").select("following_question_id").eq("id", questionId).single();
 
         if (!data?.following_question_id) {
             return null; // Not part of any chain
@@ -418,6 +408,9 @@ export const hideAllForQuestion = async (questionId: number, performanceId: numb
 
 export const hideAllQuestionsForPerformance = async (performanceId: number) => {
     const supabase = await createClient();
-    await supabase.from("questions").update({ audience_visibility: "hidden", state: "hidden" }).eq("performance_id", performanceId);
+    await supabase
+        .from("questions")
+        .update({ audience_visibility: "hidden", state: "hidden" })
+        .eq("performance_id", performanceId);
     revalidatePath(`/admin/performances/${performanceId}`);
 };

--- a/api/submit-answer.ts
+++ b/api/submit-answer.ts
@@ -4,7 +4,16 @@ import { PostgrestSingleResponse } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 import { fetchQuestionState } from "@/api/questions.api";
-import type { MatchAnswer, MatchAnswerCreate, OptionsAnswer, OptionsAnswerInsert, TextAnswer, TextAnswerInsert, VoteAnswer, VoteAnswerInsert } from "@/api/types.api";
+import type {
+    MatchAnswer,
+    MatchAnswerCreate,
+    OptionsAnswer,
+    OptionsAnswerInsert,
+    TextAnswer,
+    TextAnswerInsert,
+    VoteAnswer,
+    VoteAnswerInsert,
+} from "@/api/types.api";
 import { COOKIE_USER_ID } from "@/utils/constants.utils";
 import { createClient } from "@/utils/supabase/server";
 
@@ -53,7 +62,10 @@ export const submitOptionsAnswer = async (answer: OptionsAnswerInsert) => {
 
     let response;
     if (existing) {
-        response = await supabase.from("answers_options").update({ question_options_id: answer.question_options_id }).eq("id", existing.id);
+        response = await supabase
+            .from("answers_options")
+            .update({ question_options_id: answer.question_options_id })
+            .eq("id", existing.id);
     } else {
         response = await supabase.from("answers_options").insert({ ...answer, user_id });
     }
@@ -104,11 +116,7 @@ export const submitMatchAnswer = async (answers: MatchAnswerCreate[]) => {
 
     // Delete existing matches for this question, then insert new ones
     if (answers.length > 0) {
-        await supabase
-            .from("answers_match")
-            .delete()
-            .eq("question_id", answers[0].question_id)
-            .eq("user_id", user_id);
+        await supabase.from("answers_match").delete().eq("question_id", answers[0].question_id).eq("user_id", user_id);
     }
 
     const responses = [];

--- a/api/types.api.ts
+++ b/api/types.api.ts
@@ -7,11 +7,15 @@ export type OptionInput = {
     option: string;
 };
 
-export type QuestionWithPlayersAndCharacters = Question & { players: Player[]; characters: Character[]; options: QuestionOptions[] };
+export type QuestionWithPlayersAndCharacters = Question & {
+    players: Player[];
+    characters: Character[];
+    options: QuestionOptions[];
+};
 export type QuestionWithPool = Question & { questions_pool: Pick<Tables<"questions_pool">, "id" | "name"> | null };
 export type QuestionDetail = QuestionWithPlayersAndCharacters & QuestionWithPool;
 export type CharacterInput = {
-    id?: number;  // undefined for new, present for existing
+    id?: number; // undefined for new, present for existing
     name: string;
     description?: string | null;
 };
@@ -74,17 +78,17 @@ export type PerformanceState = Enums<"performance-state">;
 
 // Performance Management Types (T008)
 export type PerformanceWithPlayers = Performance & {
-  players: Player[];
+    players: Player[];
 };
 
 export type PerformanceFormData = {
-  name: string;
-  date: string; // ISO 8601
-  intro_text?: string;
-  url_slug?: string;
-  state?: "draft" | "intro" | "life" | "finished" | "closing";
+    name: string;
+    date: string; // ISO 8601
+    intro_text?: string;
+    url_slug?: string;
+    state?: "draft" | "intro" | "life" | "finished" | "closing";
 };
 
 export type ServerActionResult<T> =
-  | { success: true; data: T }
-  | { success: false; error: string; fieldErrors?: Record<string, string[]> };
+    | { success: true; data: T }
+    | { success: false; error: string; fieldErrors?: Record<string, string[]> };

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -28,7 +28,7 @@ export default async function Performances() {
                 <h1 className="text-4xl font-bold">Představení</h1>
                 <div className="flex gap-2">
                     <Button variant="outline" asChild>
-                        <Link href="/admin/players">Hráči</Link>
+                        <Link href="/admin/players">Improvizátoři</Link>
                     </Button>
                     <Button asChild>
                         <Link href="/admin/performances/new">Vytvořit představení</Link>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -26,9 +26,14 @@ export default async function Performances() {
         <>
             <div className="mb-6 flex items-center justify-between">
                 <h1 className="text-4xl font-bold">Představení</h1>
-                <Button asChild>
-                    <Link href="/admin/performances/new">Vytvořit představení</Link>
-                </Button>
+                <div className="flex gap-2">
+                    <Button variant="outline" asChild>
+                        <Link href="/admin/players">Hráči</Link>
+                    </Button>
+                    <Button asChild>
+                        <Link href="/admin/performances/new">Vytvořit představení</Link>
+                    </Button>
+                </div>
             </div>
             <PerformanceList performances={performances} />
         </>

--- a/app/admin/performances/[performanceId]/edit/page.tsx
+++ b/app/admin/performances/[performanceId]/edit/page.tsx
@@ -55,7 +55,7 @@ export default async function EditPerformancePage({ params }: { params: Promise<
             <PerformanceForm initialData={performance} action={handleUpdate} submitLabel="Uložit změny" />
 
             <div className="mt-8 rounded-lg border border-gray-800 bg-gray-950 p-6">
-                <h2 className="mb-4 text-xl font-semibold">Správa hráčů</h2>
+                <h2 className="mb-4 text-xl font-semibold">Správa improvizátorů</h2>
                 <PlayerAssignment
                     performanceId={performance.id}
                     assignedPlayers={performance.players}

--- a/app/admin/performances/[performanceId]/page.tsx
+++ b/app/admin/performances/[performanceId]/page.tsx
@@ -40,7 +40,7 @@ export default async function PerformanceDetail(props: { params: Promise<{ perfo
                 </Link>
             </div>
 
-            <h2 className="text-xl font-semibold mb-4 mt-6">Otázky</h2>
+            <h2 className="mb-4 mt-6 text-xl font-semibold">Otázky</h2>
             <List>
                 {questions.map((question) => (
                     <QuestionItem key={question.id} {...question} />

--- a/app/admin/players/[playerId]/edit/page.tsx
+++ b/app/admin/players/[playerId]/edit/page.tsx
@@ -50,7 +50,7 @@ export default async function EditPlayerPage({ params }: { params: Promise<{ pla
     }
 
     return (
-        <div className="space-y-8">
+        <div className="space-y-8 pb-8">
             <div className="flex items-center gap-2">
                 <Button variant="ghost" size="icon" asChild className="h-auto">
                     <Link href="/admin/players">

--- a/app/admin/players/[playerId]/edit/page.tsx
+++ b/app/admin/players/[playerId]/edit/page.tsx
@@ -63,7 +63,7 @@ export default async function EditPlayerPage({ params }: { params: Promise<{ pla
             </div>
 
             <div>
-                <h2 className="mb-4 text-xl font-semibold">Údaje hráče</h2>
+                <h2 className="mb-4 text-xl font-semibold">Údaje improvizátora</h2>
                 <PlayerForm initialData={player} action={handleUpdate} submitLabel="Uložit změny" />
             </div>
 

--- a/app/admin/players/[playerId]/edit/page.tsx
+++ b/app/admin/players/[playerId]/edit/page.tsx
@@ -2,9 +2,10 @@ import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
-import { fetchPlayer, updatePlayer } from "@/api/players.api";
+import { fetchPlayer, fetchPlayerPerformances, updatePlayer } from "@/api/players.api";
 import { PlayerForm } from "@/components/admin/players/PlayerForm";
 import { PlayerName } from "@/components/admin/players/PlayerName";
+import { PlayerPerformances } from "@/components/admin/players/PlayerPerformances";
 import { PlayerPhotos } from "@/components/admin/players/PlayerPhotos";
 import { Button } from "@/components/ui/Button";
 import { createClient } from "@/utils/supabase/server";
@@ -28,6 +29,8 @@ export default async function EditPlayerPage({ params }: { params: Promise<{ pla
     }
 
     const player = result.data;
+    const performancesResult = await fetchPlayerPerformances(player.id);
+    const performances = performancesResult.success ? performancesResult.data : [];
 
     async function handleUpdate(prevState: unknown, formData: FormData) {
         "use server";
@@ -66,6 +69,10 @@ export default async function EditPlayerPage({ params }: { params: Promise<{ pla
 
             <div className="rounded-lg border border-border p-6">
                 <PlayerPhotos player={player} />
+            </div>
+
+            <div className="rounded-lg border border-border p-6">
+                <PlayerPerformances performances={performances} />
             </div>
         </div>
     );

--- a/app/admin/players/[playerId]/edit/page.tsx
+++ b/app/admin/players/[playerId]/edit/page.tsx
@@ -1,0 +1,72 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { fetchPlayer, updatePlayer } from "@/api/players.api";
+import { PlayerForm } from "@/components/admin/players/PlayerForm";
+import { PlayerName } from "@/components/admin/players/PlayerName";
+import { PlayerPhotos } from "@/components/admin/players/PlayerPhotos";
+import { Button } from "@/components/ui/Button";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function EditPlayerPage({ params }: { params: Promise<{ playerId: string }> }) {
+    const { playerId } = await params;
+    const supabase = await createClient();
+
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+        redirect("/login");
+    }
+
+    const result = await fetchPlayer(parseInt(playerId));
+
+    if (!result.success) {
+        notFound();
+    }
+
+    const player = result.data;
+
+    async function handleUpdate(prevState: unknown, formData: FormData) {
+        "use server";
+        const result = await updatePlayer({
+            id: player.id,
+            name: formData.get("name") as string,
+            surname: (formData.get("surname") as string) || null,
+            motto: (formData.get("motto") as string) || null,
+            quest: formData.get("quest") === "true",
+        });
+
+        if (result.success) {
+            redirect(`/admin/players/${player.id}/edit`);
+        }
+
+        return result;
+    }
+
+    return (
+        <div className="space-y-8">
+            <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" asChild className="h-auto">
+                    <Link href="/admin/players">
+                        <ChevronLeft size={28} />
+                    </Link>
+                </Button>
+                <h1 className="text-3xl font-bold">
+                    <PlayerName player={player} />
+                </h1>
+            </div>
+
+            <div>
+                <h2 className="mb-4 text-xl font-semibold">Údaje hráče</h2>
+                <PlayerForm initialData={player} action={handleUpdate} submitLabel="Uložit změny" />
+            </div>
+
+            <div className="rounded-lg border border-border p-6">
+                <PlayerPhotos player={player} />
+            </div>
+        </div>
+    );
+}

--- a/app/admin/players/new/page.tsx
+++ b/app/admin/players/new/page.tsx
@@ -33,7 +33,9 @@ export default function NewPlayerPage() {
                 </Button>
                 <div>
                     <h1 className="text-3xl font-bold">Nový improvizátor</h1>
-                    <p className="mt-2 text-gray-400">Vytvořte nového improvizátora a po vytvoření přidejte fotografie</p>
+                    <p className="mt-2 text-gray-400">
+                        Vytvořte nového improvizátora a po vytvoření přidejte fotografie
+                    </p>
                 </div>
             </div>
 

--- a/app/admin/players/new/page.tsx
+++ b/app/admin/players/new/page.tsx
@@ -1,0 +1,43 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createPlayer } from "@/api/players.api";
+import { PlayerForm } from "@/components/admin/players/PlayerForm";
+import { Button } from "@/components/ui/Button";
+
+export default function NewPlayerPage() {
+    async function handleCreate(prevState: unknown, formData: FormData) {
+        "use server";
+        const result = await createPlayer({
+            name: formData.get("name") as string,
+            surname: (formData.get("surname") as string) || undefined,
+            motto: (formData.get("motto") as string) || undefined,
+            quest: formData.get("quest") === "true",
+        });
+
+        if (result.success) {
+            redirect(`/admin/players/${result.data.id}/edit`);
+        }
+
+        return result;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" asChild className="h-auto">
+                    <Link href="/admin/players">
+                        <ChevronLeft size={28} />
+                    </Link>
+                </Button>
+                <div>
+                    <h1 className="text-3xl font-bold">Nový hráč</h1>
+                    <p className="mt-2 text-gray-400">Vytvořte nového hráče a po vytvoření přidejte fotografie</p>
+                </div>
+            </div>
+
+            <PlayerForm action={handleCreate} submitLabel="Vytvořit hráče" />
+        </div>
+    );
+}

--- a/app/admin/players/new/page.tsx
+++ b/app/admin/players/new/page.tsx
@@ -32,12 +32,12 @@ export default function NewPlayerPage() {
                     </Link>
                 </Button>
                 <div>
-                    <h1 className="text-3xl font-bold">Nový hráč</h1>
-                    <p className="mt-2 text-gray-400">Vytvořte nového hráče a po vytvoření přidejte fotografie</p>
+                    <h1 className="text-3xl font-bold">Nový improvizátor</h1>
+                    <p className="mt-2 text-gray-400">Vytvořte nového improvizátora a po vytvoření přidejte fotografie</p>
                 </div>
             </div>
 
-            <PlayerForm action={handleCreate} submitLabel="Vytvořit hráče" />
+            <PlayerForm action={handleCreate} submitLabel="Přidat improvizátora" />
         </div>
     );
 }

--- a/app/admin/players/page.tsx
+++ b/app/admin/players/page.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -25,7 +26,14 @@ export default async function Players() {
     return (
         <>
             <div className="mb-6 flex items-center justify-between">
-                <h1 className="text-4xl font-bold">Improvizátoři</h1>
+                <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon" asChild className="h-auto">
+                        <Link href="/admin">
+                            <ChevronLeft size={28} />
+                        </Link>
+                    </Button>
+                    <h1 className="text-4xl font-bold">Improvizátoři</h1>
+                </div>
                 <Button asChild>
                     <Link href="/admin/players/new">Přidat improvizátora</Link>
                 </Button>

--- a/app/admin/players/page.tsx
+++ b/app/admin/players/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { fetchPlayers } from "@/api/players.api";
+import { PlayerList } from "@/components/admin/players/PlayerList";
+import { Button } from "@/components/ui/Button";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function Players() {
+    const supabase = await createClient();
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+        redirect("/login");
+    }
+
+    const result = await fetchPlayers();
+
+    if (!result.success) {
+        throw new Error(`Chyba při načítání hráčů: ${result.error}`);
+    }
+
+    return (
+        <>
+            <div className="mb-6 flex items-center justify-between">
+                <h1 className="text-4xl font-bold">Hráči</h1>
+                <Button asChild>
+                    <Link href="/admin/players/new">Vytvořit hráče</Link>
+                </Button>
+            </div>
+            <PlayerList players={result.data} />
+        </>
+    );
+}

--- a/app/admin/players/page.tsx
+++ b/app/admin/players/page.tsx
@@ -19,15 +19,15 @@ export default async function Players() {
     const result = await fetchPlayers();
 
     if (!result.success) {
-        throw new Error(`Chyba při načítání hráčů: ${result.error}`);
+        throw new Error(`Chyba při načítání improvizátorů: ${result.error}`);
     }
 
     return (
         <>
             <div className="mb-6 flex items-center justify-between">
-                <h1 className="text-4xl font-bold">Hráči</h1>
+                <h1 className="text-4xl font-bold">Improvizátoři</h1>
                 <Button asChild>
-                    <Link href="/admin/players/new">Vytvořit hráče</Link>
+                    <Link href="/admin/players/new">Přidat improvizátora</Link>
                 </Button>
             </div>
             <PlayerList players={result.data} />

--- a/app/admin/questions/[questionId]/view/page.tsx
+++ b/app/admin/questions/[questionId]/view/page.tsx
@@ -117,7 +117,7 @@ export default async function QuestionDetail(props: { params: Promise<{ question
                     </header>
 
                     <div className={"grid gap-4 lg:grid-cols-2"}>
-                        <VisCard icon={<SmartphoneIcon size={14} />} title={"Hráči (telefon)"}>
+                        <VisCard icon={<SmartphoneIcon size={14} />} title={"Diváci (telefon)"}>
                             <QuestionUserStateToggle defaultState={question.state} question={question} />
                         </VisCard>
                         <VisCard icon={<ProjectorIcon size={14} />} title={"Diváci / projekce"}>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -46,7 +46,7 @@ export default async function Login(props: { searchParams: Promise<{ message: st
                     Sign In
                 </Button>
                 {searchParams?.message && (
-                    <p className="mt-4 bg-foreground/10 p-4 text-center text-foreground">{searchParams.message}</p>
+                    <p className="bg-foreground/10 mt-4 p-4 text-center text-foreground">{searchParams.message}</p>
                 )}
             </form>
         </MobileContainer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,9 +23,8 @@ export default async function PerformanceView({ params }: { params: { slug: stri
     // Fetch initial active or locked question
     const { data: initialQuestion } = await fetchActiveOrLockedQuestion(performances[0].id);
 
-    const hasMottoQuestion = performances[0].state === "intro"
-        ? await fetchHasMottoQuestion(performances[0].id)
-        : false;
+    const hasMottoQuestion =
+        performances[0].state === "intro" ? await fetchHasMottoQuestion(performances[0].id) : false;
 
     return (
         <AuthUser>

--- a/components/admin/answers/Answers.tsx
+++ b/components/admin/answers/Answers.tsx
@@ -31,10 +31,22 @@ export const Answers = ({ question, questionOptions, initialAnswers }: Props) =>
                     />
                 );
             case "options":
-                return <OptionsAnswers questionId={question.id} options={questionOptions} initialAnswers={initialAnswers as any} />;
+                return (
+                    <OptionsAnswers
+                        questionId={question.id}
+                        options={questionOptions}
+                        initialAnswers={initialAnswers as any}
+                    />
+                );
             case "voting":
             case "player-pick":
-                return <PlayersVotingAnswers questionId={question.id} players={question.players} initialAnswers={initialAnswers as any} />;
+                return (
+                    <PlayersVotingAnswers
+                        questionId={question.id}
+                        players={question.players}
+                        initialAnswers={initialAnswers as any}
+                    />
+                );
         }
     };
     return (

--- a/components/admin/performances/PlayerAssignment.tsx
+++ b/components/admin/performances/PlayerAssignment.tsx
@@ -61,7 +61,7 @@ export function PlayerAssignment({
     setIsAssigning(false);
 
     if (result.success) {
-      setMessage({ type: "success", text: "Hráč byl přiřazen" });
+      setMessage({ type: "success", text: "Improvizátor byl přiřazen" });
       setSelectedPlayerId("");
       setTimeout(() => setMessage(null), 3000);
     } else {
@@ -79,7 +79,7 @@ export function PlayerAssignment({
     setRemovingPlayerId(null);
 
     if (result.success) {
-      setMessage({ type: "success", text: "Hráč byl odstraněn" });
+      setMessage({ type: "success", text: "Improvizátor byl odstraněn" });
       setTimeout(() => setMessage(null), 3000);
     } else {
       setMessage({ type: "error", text: result.error });
@@ -112,16 +112,16 @@ export function PlayerAssignment({
 
       {/* Add Player Section */}
       <div>
-        <Label htmlFor="player-select">Přidat hráče</Label>
+        <Label htmlFor="player-select">Přidat Improvizátora</Label>
         <div className="flex gap-2 mt-2">
           <Select value={selectedPlayerId} onValueChange={setSelectedPlayerId}>
-            <SelectTrigger className="flex-1" aria-label="Výběr hráče">
-              <SelectValue placeholder="Vyberte hráče" />
+            <SelectTrigger className="flex-1" aria-label="Výběr improvizátora">
+              <SelectValue placeholder="Vyberte improvizátora" />
             </SelectTrigger>
             <SelectContent>
               {unassignedPlayers.length === 0 ? (
                 <SelectItem value="" disabled>
-                  Všichni hráči jsou již přiřazeni
+                  Všichni improvizátoři jsou již přiřazeni
                 </SelectItem>
               ) : (
                 unassignedPlayers.map((player) => (
@@ -136,7 +136,7 @@ export function PlayerAssignment({
             type="button"
             onClick={handleAssign}
             disabled={!selectedPlayerId || isAssigning}
-            aria-label="Přidat vybraného hráče"
+            aria-label="Přidat vybraného improvizátora"
           >
             {isAssigning ? "Přidávání..." : "Přidat"}
           </Button>
@@ -145,13 +145,13 @@ export function PlayerAssignment({
 
       {/* Assigned Players List */}
       <div>
-        <Label>Přiřazení hráči ({assignedPlayers.length})</Label>
+        <Label>Přiřazení improvizátora ({assignedPlayers.length})</Label>
         {assignedPlayers.length === 0 ? (
           <p className="text-sm text-gray-500 mt-2">
-            Zatím nejsou přiřazeni žádní hráči
+            Zatím nejsou přiřazeni žádní improvizátoři
           </p>
         ) : (
-          <ul className="mt-2 space-y-2" role="list" aria-label="Seznam přiřazených hráčů">
+          <ul className="mt-2 space-y-2" role="list" aria-label="Seznam přiřazených improvizátorů">
             {assignedPlayers.map((player) => (
               <li
                 key={player.id}
@@ -164,7 +164,7 @@ export function PlayerAssignment({
                   size="sm"
                   onClick={() => handleRemove(player.id)}
                   disabled={removingPlayerId === player.id}
-                  aria-label={`Odebrat hráče ${formatPlayerName(player)}`}
+                  aria-label={`Odebrat improvizátora ${formatPlayerName(player)}`}
                 >
                   {removingPlayerId === player.id ? "Odebírání..." : "Odebrat"}
                 </Button>

--- a/components/admin/performances/PlayerAssignment.tsx
+++ b/components/admin/performances/PlayerAssignment.tsx
@@ -2,177 +2,151 @@
 
 import { useActionState, useState } from "react";
 
-import {
-  assignPlayerToPerformance,
-  removePlayerFromPerformance,
-  type Player,
-} from "@/api/performances.api";
+import { assignPlayerToPerformance, removePlayerFromPerformance, type Player } from "@/api/performances.api";
 import { Button } from "@/components/ui/Button";
 import { Label } from "@/components/ui/Label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/Select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/Select";
 
 type PlayerAssignmentProps = {
-  performanceId: number;
-  assignedPlayers: Player[];
-  availablePlayers: Player[];
+    performanceId: number;
+    assignedPlayers: Player[];
+    availablePlayers: Player[];
 };
 
 // Formats player display name: "Name Surname" with optional "(host)" suffix
 // Shows surname if available, appends "(host)" for guest performers (quest=true)
 function formatPlayerName(player: Player): string {
-  const fullName = player.surname
-    ? `${player.name} ${player.surname}`
-    : player.name;
-  return player.quest ? `${fullName} (host)` : fullName;
+    const fullName = player.surname ? `${player.name} ${player.surname}` : player.name;
+    return player.quest ? `${fullName} (host)` : fullName;
 }
 
-export function PlayerAssignment({
-  performanceId,
-  assignedPlayers,
-  availablePlayers,
-}: PlayerAssignmentProps) {
-  const [selectedPlayerId, setSelectedPlayerId] = useState<string>("");
-  const [isAssigning, setIsAssigning] = useState(false);
-  const [removingPlayerId, setRemovingPlayerId] = useState<number | null>(null);
-  const [message, setMessage] = useState<{
-    type: "success" | "error";
-    text: string;
-  } | null>(null);
+export function PlayerAssignment({ performanceId, assignedPlayers, availablePlayers }: PlayerAssignmentProps) {
+    const [selectedPlayerId, setSelectedPlayerId] = useState<string>("");
+    const [isAssigning, setIsAssigning] = useState(false);
+    const [removingPlayerId, setRemovingPlayerId] = useState<number | null>(null);
+    const [message, setMessage] = useState<{
+        type: "success" | "error";
+        text: string;
+    } | null>(null);
 
-  // Get players not already assigned
-  const unassignedPlayers = availablePlayers.filter(
-    (player) => !assignedPlayers.some((ap) => ap.id === player.id),
-  );
+    // Get players not already assigned
+    const unassignedPlayers = availablePlayers.filter((player) => !assignedPlayers.some((ap) => ap.id === player.id));
 
-  async function handleAssign() {
-    if (!selectedPlayerId) return;
+    async function handleAssign() {
+        if (!selectedPlayerId) return;
 
-    setIsAssigning(true);
-    const result = await assignPlayerToPerformance({
-      performance_id: performanceId,
-      player_id: parseInt(selectedPlayerId),
-    });
-    setIsAssigning(false);
+        setIsAssigning(true);
+        const result = await assignPlayerToPerformance({
+            performance_id: performanceId,
+            player_id: parseInt(selectedPlayerId),
+        });
+        setIsAssigning(false);
 
-    if (result.success) {
-      setMessage({ type: "success", text: "Improvizátor byl přiřazen" });
-      setSelectedPlayerId("");
-      setTimeout(() => setMessage(null), 3000);
-    } else {
-      setMessage({ type: "error", text: result.error });
-      setTimeout(() => setMessage(null), 5000);
+        if (result.success) {
+            setMessage({ type: "success", text: "Improvizátor byl přiřazen" });
+            setSelectedPlayerId("");
+            setTimeout(() => setMessage(null), 3000);
+        } else {
+            setMessage({ type: "error", text: result.error });
+            setTimeout(() => setMessage(null), 5000);
+        }
     }
-  }
 
-  async function handleRemove(playerId: number) {
-    setRemovingPlayerId(playerId);
-    const result = await removePlayerFromPerformance({
-      performance_id: performanceId,
-      player_id: playerId,
-    });
-    setRemovingPlayerId(null);
+    async function handleRemove(playerId: number) {
+        setRemovingPlayerId(playerId);
+        const result = await removePlayerFromPerformance({
+            performance_id: performanceId,
+            player_id: playerId,
+        });
+        setRemovingPlayerId(null);
 
-    if (result.success) {
-      setMessage({ type: "success", text: "Improvizátor byl odstraněn" });
-      setTimeout(() => setMessage(null), 3000);
-    } else {
-      setMessage({ type: "error", text: result.error });
-      setTimeout(() => setMessage(null), 5000);
+        if (result.success) {
+            setMessage({ type: "success", text: "Improvizátor byl odstraněn" });
+            setTimeout(() => setMessage(null), 3000);
+        } else {
+            setMessage({ type: "error", text: result.error });
+            setTimeout(() => setMessage(null), 5000);
+        }
     }
-  }
 
-  return (
-    <div className="space-y-6">
-      {/* Message Display */}
-      {message && (
-        <div
-          role={message.type === "error" ? "alert" : "status"}
-          aria-live="polite"
-          className={`p-4 border rounded ${
-            message.type === "success"
-              ? "bg-green-950 border-green-800"
-              : "bg-red-950 border-red-800"
-          }`}
-        >
-          <p
-            className={`text-sm ${
-              message.type === "success" ? "text-green-200" : "text-red-200"
-            }`}
-          >
-            {message.text}
-          </p>
-        </div>
-      )}
-
-      {/* Add Player Section */}
-      <div>
-        <Label htmlFor="player-select">Přidat Improvizátora</Label>
-        <div className="flex gap-2 mt-2">
-          <Select value={selectedPlayerId} onValueChange={setSelectedPlayerId}>
-            <SelectTrigger className="flex-1" aria-label="Výběr improvizátora">
-              <SelectValue placeholder="Vyberte improvizátora" />
-            </SelectTrigger>
-            <SelectContent>
-              {unassignedPlayers.length === 0 ? (
-                <SelectItem value="" disabled>
-                  Všichni improvizátoři jsou již přiřazeni
-                </SelectItem>
-              ) : (
-                unassignedPlayers.map((player) => (
-                  <SelectItem key={player.id} value={player.id.toString()}>
-                    {formatPlayerName(player)}
-                  </SelectItem>
-                ))
-              )}
-            </SelectContent>
-          </Select>
-          <Button
-            type="button"
-            onClick={handleAssign}
-            disabled={!selectedPlayerId || isAssigning}
-            aria-label="Přidat vybraného improvizátora"
-          >
-            {isAssigning ? "Přidávání..." : "Přidat"}
-          </Button>
-        </div>
-      </div>
-
-      {/* Assigned Players List */}
-      <div>
-        <Label>Přiřazení improvizátora ({assignedPlayers.length})</Label>
-        {assignedPlayers.length === 0 ? (
-          <p className="text-sm text-gray-500 mt-2">
-            Zatím nejsou přiřazeni žádní improvizátoři
-          </p>
-        ) : (
-          <ul className="mt-2 space-y-2" role="list" aria-label="Seznam přiřazených improvizátorů">
-            {assignedPlayers.map((player) => (
-              <li
-                key={player.id}
-                className="flex items-center justify-between p-3 bg-gray-900 rounded border border-gray-700"
-              >
-                <span className="font-medium">{formatPlayerName(player)}</span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleRemove(player.id)}
-                  disabled={removingPlayerId === player.id}
-                  aria-label={`Odebrat improvizátora ${formatPlayerName(player)}`}
+    return (
+        <div className="space-y-6">
+            {/* Message Display */}
+            {message && (
+                <div
+                    role={message.type === "error" ? "alert" : "status"}
+                    aria-live="polite"
+                    className={`rounded border p-4 ${
+                        message.type === "success" ? "border-green-800 bg-green-950" : "border-red-800 bg-red-950"
+                    }`}
                 >
-                  {removingPlayerId === player.id ? "Odebírání..." : "Odebrat"}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
+                    <p className={`text-sm ${message.type === "success" ? "text-green-200" : "text-red-200"}`}>
+                        {message.text}
+                    </p>
+                </div>
+            )}
+
+            {/* Add Player Section */}
+            <div>
+                <Label htmlFor="player-select">Přidat Improvizátora</Label>
+                <div className="mt-2 flex gap-2">
+                    <Select value={selectedPlayerId} onValueChange={setSelectedPlayerId}>
+                        <SelectTrigger className="flex-1" aria-label="Výběr improvizátora">
+                            <SelectValue placeholder="Vyberte improvizátora" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {unassignedPlayers.length === 0 ? (
+                                <SelectItem value="" disabled>
+                                    Všichni improvizátoři jsou již přiřazeni
+                                </SelectItem>
+                            ) : (
+                                unassignedPlayers.map((player) => (
+                                    <SelectItem key={player.id} value={player.id.toString()}>
+                                        {formatPlayerName(player)}
+                                    </SelectItem>
+                                ))
+                            )}
+                        </SelectContent>
+                    </Select>
+                    <Button
+                        type="button"
+                        onClick={handleAssign}
+                        disabled={!selectedPlayerId || isAssigning}
+                        aria-label="Přidat vybraného improvizátora"
+                    >
+                        {isAssigning ? "Přidávání..." : "Přidat"}
+                    </Button>
+                </div>
+            </div>
+
+            {/* Assigned Players List */}
+            <div>
+                <Label>Přiřazení improvizátora ({assignedPlayers.length})</Label>
+                {assignedPlayers.length === 0 ? (
+                    <p className="mt-2 text-sm text-gray-500">Zatím nejsou přiřazeni žádní improvizátoři</p>
+                ) : (
+                    <ul className="mt-2 space-y-2" role="list" aria-label="Seznam přiřazených improvizátorů">
+                        {assignedPlayers.map((player) => (
+                            <li
+                                key={player.id}
+                                className="flex items-center justify-between rounded border border-gray-700 bg-gray-900 p-3"
+                            >
+                                <span className="font-medium">{formatPlayerName(player)}</span>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleRemove(player.id)}
+                                    disabled={removingPlayerId === player.id}
+                                    aria-label={`Odebrat improvizátora ${formatPlayerName(player)}`}
+                                >
+                                    {removingPlayerId === player.id ? "Odebírání..." : "Odebrat"}
+                                </Button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
 }

--- a/components/admin/players/PlayerAvatar.tsx
+++ b/components/admin/players/PlayerAvatar.tsx
@@ -39,7 +39,7 @@ export function PlayerAvatar({ player, size = 40 }: Props) {
                 style={{ width: size, height: size, fontSize: Math.round(size * 0.45) }}
                 aria-label={player.name}
             >
-                {player.name[0].toUpperCase()}
+                {player.name?.[0]?.toUpperCase() ?? "?"}
             </div>
         );
     }

--- a/components/admin/players/PlayerAvatar.tsx
+++ b/components/admin/players/PlayerAvatar.tsx
@@ -1,0 +1,59 @@
+"use client";
+import Image from "next/image";
+import { useState } from "react";
+
+import { getPlayerPhotos } from "@/api/photos.api";
+import type { Player } from "@/api/types.api";
+
+const COLORS = [
+    "bg-red-500",
+    "bg-blue-500",
+    "bg-emerald-500",
+    "bg-purple-500",
+    "bg-orange-500",
+    "bg-pink-500",
+    "bg-teal-500",
+];
+
+function pickColor(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) & 0xff;
+    }
+    return COLORS[hash % COLORS.length];
+}
+
+type Props = {
+    player: Player;
+    size?: number;
+};
+
+export function PlayerAvatar({ player, size = 40 }: Props) {
+    const [imgError, setImgError] = useState(false);
+    const { profile } = getPlayerPhotos(player.id);
+
+    if (imgError) {
+        return (
+            <div
+                className={`${pickColor(player.name)} flex shrink-0 items-center justify-center rounded-full font-bold text-white`}
+                style={{ width: size, height: size, fontSize: Math.round(size * 0.45) }}
+                aria-label={player.name}
+            >
+                {player.name[0].toUpperCase()}
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative shrink-0 overflow-hidden rounded-full" style={{ width: size, height: size }}>
+            <Image
+                src={profile}
+                alt={player.name}
+                fill
+                sizes={`${size}px`}
+                className="object-cover"
+                onError={() => setImgError(true)}
+            />
+        </div>
+    );
+}

--- a/components/admin/players/PlayerForm.tsx
+++ b/components/admin/players/PlayerForm.tsx
@@ -26,7 +26,7 @@ export function PlayerForm({ initialData, action, submitLabel = "Uložit" }: Pro
     const formState = state as { error?: string; fieldErrors?: Record<string, string[]> } | null;
 
     return (
-        <form action={formAction} className="space-y-6" aria-label="Formulář hráče">
+        <form action={formAction} className="space-y-6" aria-label="Formulář improvizátora">
             {initialData && <input type="hidden" name="id" value={initialData.id} />}
             <input type="hidden" name="quest" value={quest ? "true" : "false"} />
 
@@ -70,7 +70,7 @@ export function PlayerForm({ initialData, action, submitLabel = "Uložit" }: Pro
                     onChange={(e) => setMotto(e.target.value)}
                     rows={3}
                     maxLength={500}
-                    placeholder="Krátké motto nebo bio hráče"
+                    placeholder="Krátké motto nebo bio improvizátora"
                 />
                 {formState?.fieldErrors?.motto && (
                     <p className="mt-1 text-sm text-red-600">{formState.fieldErrors.motto[0]}</p>
@@ -84,7 +84,7 @@ export function PlayerForm({ initialData, action, submitLabel = "Uložit" }: Pro
                     onCheckedChange={setQuest}
                     aria-label="Host"
                 />
-                <Label htmlFor="quest-switch">Host (označí hráče jako hostitele)</Label>
+                <Label htmlFor="quest-switch">Host (označí improvizátora jako hosta)</Label>
             </div>
 
             {formState?.error && !formState?.fieldErrors && (

--- a/components/admin/players/PlayerForm.tsx
+++ b/components/admin/players/PlayerForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useActionState, useState } from "react";
+
+import type { Player } from "@/api/types.api";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { Switch } from "@/components/ui/Switch";
+import { Textarea } from "@/components/ui/Textarea";
+
+type Props = {
+    initialData?: Player;
+    action: (prevState: unknown, formData: FormData) => Promise<unknown>;
+    submitLabel?: string;
+};
+
+export function PlayerForm({ initialData, action, submitLabel = "Uložit" }: Props) {
+    const [state, formAction, isPending] = useActionState(action, null);
+
+    const [name, setName] = useState(initialData?.name ?? "");
+    const [surname, setSurname] = useState(initialData?.surname ?? "");
+    const [motto, setMotto] = useState(initialData?.motto ?? "");
+    const [quest, setQuest] = useState(initialData?.quest ?? false);
+
+    const formState = state as { error?: string; fieldErrors?: Record<string, string[]> } | null;
+
+    return (
+        <form action={formAction} className="space-y-6" aria-label="Formulář hráče">
+            {initialData && <input type="hidden" name="id" value={initialData.id} />}
+            <input type="hidden" name="quest" value={quest ? "true" : "false"} />
+
+            <div>
+                <Label htmlFor="name">Jméno *</Label>
+                <Input
+                    id="name"
+                    name="name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    required
+                    maxLength={255}
+                    placeholder="např. Jana"
+                />
+                {formState?.fieldErrors?.name && (
+                    <p className="mt-1 text-sm text-red-600">{formState.fieldErrors.name[0]}</p>
+                )}
+            </div>
+
+            <div>
+                <Label htmlFor="surname">Příjmení</Label>
+                <Input
+                    id="surname"
+                    name="surname"
+                    value={surname}
+                    onChange={(e) => setSurname(e.target.value)}
+                    maxLength={255}
+                    placeholder="např. Nováková"
+                />
+                {formState?.fieldErrors?.surname && (
+                    <p className="mt-1 text-sm text-red-600">{formState.fieldErrors.surname[0]}</p>
+                )}
+            </div>
+
+            <div>
+                <Label htmlFor="motto">Motto</Label>
+                <Textarea
+                    id="motto"
+                    name="motto"
+                    value={motto}
+                    onChange={(e) => setMotto(e.target.value)}
+                    rows={3}
+                    maxLength={500}
+                    placeholder="Krátké motto nebo bio hráče"
+                />
+                {formState?.fieldErrors?.motto && (
+                    <p className="mt-1 text-sm text-red-600">{formState.fieldErrors.motto[0]}</p>
+                )}
+            </div>
+
+            <div className="flex items-center gap-3">
+                <Switch
+                    id="quest-switch"
+                    checked={quest}
+                    onCheckedChange={setQuest}
+                    aria-label="Host"
+                />
+                <Label htmlFor="quest-switch">Host (označí hráče jako hostitele)</Label>
+            </div>
+
+            {formState?.error && !formState?.fieldErrors && (
+                <div role="alert" aria-live="assertive" className="rounded border border-red-800 bg-red-950 p-4">
+                    <p className="text-sm text-red-200">{formState.error}</p>
+                </div>
+            )}
+
+            <div className="flex gap-4">
+                <Button type="submit" disabled={isPending}>
+                    {isPending ? "Ukládání..." : submitLabel}
+                </Button>
+            </div>
+        </form>
+    );
+}

--- a/components/admin/players/PlayerForm.tsx
+++ b/components/admin/players/PlayerForm.tsx
@@ -78,12 +78,7 @@ export function PlayerForm({ initialData, action, submitLabel = "Uložit" }: Pro
             </div>
 
             <div className="flex items-center gap-3">
-                <Switch
-                    id="quest-switch"
-                    checked={quest}
-                    onCheckedChange={setQuest}
-                    aria-label="Host"
-                />
+                <Switch id="quest-switch" checked={quest} onCheckedChange={setQuest} aria-label="Host" />
                 <Label htmlFor="quest-switch">Host (označí improvizátora jako hosta)</Label>
             </div>
 

--- a/components/admin/players/PlayerList.tsx
+++ b/components/admin/players/PlayerList.tsx
@@ -34,12 +34,12 @@ export function PlayerList({ players }: Props) {
                     <TableRow key={player.id}>
                         <TableCell>
                             <Link href={`/admin/players/${player.id}/edit`}>
-                            <div className="flex items-center gap-3">
-                                <PlayerAvatar player={player} />
-                                <span>
-                                    <PlayerName player={player} />
-                                </span>
-                            </div>
+                                <div className="flex items-center gap-3">
+                                    <PlayerAvatar player={player} />
+                                    <span>
+                                        <PlayerName player={player} />
+                                    </span>
+                                </div>
                             </Link>
                         </TableCell>
                     </TableRow>

--- a/components/admin/players/PlayerList.tsx
+++ b/components/admin/players/PlayerList.tsx
@@ -14,9 +14,9 @@ export function PlayerList({ players }: Props) {
     if (players.length === 0) {
         return (
             <div className="py-12 text-center">
-                <p className="text-gray-500">Zatím žádní hráči</p>
+                <p className="text-gray-500">Zatím žádní improvizátoři</p>
                 <Button className="mt-4" asChild>
-                    <Link href="/admin/players/new">Vytvořit prvního hráče</Link>
+                    <Link href="/admin/players/new">Vytvořit prvního improvizátora</Link>
                 </Button>
             </div>
         );
@@ -26,25 +26,21 @@ export function PlayerList({ players }: Props) {
         <Table>
             <TableHeader>
                 <TableRow>
-                    <TableHead>Hráč</TableHead>
-                    <TableHead className="text-right">Akce</TableHead>
+                    <TableHead>Improvizátor</TableHead>
                 </TableRow>
             </TableHeader>
             <TableBody>
                 {players.map((player) => (
                     <TableRow key={player.id}>
                         <TableCell>
+                            <Link href={`/admin/players/${player.id}/edit`}>
                             <div className="flex items-center gap-3">
                                 <PlayerAvatar player={player} />
                                 <span>
                                     <PlayerName player={player} />
                                 </span>
                             </div>
-                        </TableCell>
-                        <TableCell className="text-right">
-                            <Button variant="outline" size="sm" asChild>
-                                <Link href={`/admin/players/${player.id}/edit`}>Upravit</Link>
-                            </Button>
+                            </Link>
                         </TableCell>
                     </TableRow>
                 ))}

--- a/components/admin/players/PlayerList.tsx
+++ b/components/admin/players/PlayerList.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+
+import type { Player } from "@/api/types.api";
+import { PlayerAvatar } from "@/components/admin/players/PlayerAvatar";
+import { PlayerName } from "@/components/admin/players/PlayerName";
+import { Button } from "@/components/ui/Button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/Table";
+
+type Props = {
+    players: Player[];
+};
+
+export function PlayerList({ players }: Props) {
+    if (players.length === 0) {
+        return (
+            <div className="py-12 text-center">
+                <p className="text-gray-500">Zatím žádní hráči</p>
+                <Button className="mt-4" asChild>
+                    <Link href="/admin/players/new">Vytvořit prvního hráče</Link>
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Hráč</TableHead>
+                    <TableHead className="text-right">Akce</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {players.map((player) => (
+                    <TableRow key={player.id}>
+                        <TableCell>
+                            <div className="flex items-center gap-3">
+                                <PlayerAvatar player={player} />
+                                <span>
+                                    <PlayerName player={player} />
+                                </span>
+                            </div>
+                        </TableCell>
+                        <TableCell className="text-right">
+                            <Button variant="outline" size="sm" asChild>
+                                <Link href={`/admin/players/${player.id}/edit`}>Upravit</Link>
+                            </Button>
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+}

--- a/components/admin/players/PlayerName.tsx
+++ b/components/admin/players/PlayerName.tsx
@@ -1,0 +1,15 @@
+import type { Player } from "@/api/types.api";
+
+type Props = {
+    player: Player;
+};
+
+export function PlayerName({ player }: Props) {
+    return (
+        <>
+            <strong>{player.name}</strong>
+            {player.surname ? ` ${player.surname}` : ""}
+            {player.quest ? " - host" : ""}
+        </>
+    );
+}

--- a/components/admin/players/PlayerPerformances.tsx
+++ b/components/admin/players/PlayerPerformances.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import type { Performance } from "@/api/types.api";
-import { Button } from "@/components/ui/Button";
 import { formatDate } from "@/utils/date.utils";
 
 type Props = {

--- a/components/admin/players/PlayerPerformances.tsx
+++ b/components/admin/players/PlayerPerformances.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+import type { Performance } from "@/api/types.api";
+import { Button } from "@/components/ui/Button";
+import { formatDate } from "@/utils/date.utils";
+
+type Props = {
+    performances: Performance[];
+};
+
+export function PlayerPerformances({ performances }: Props) {
+    return (
+        <div className="space-y-3">
+            <h2 className="text-xl font-semibold">Představení</h2>
+            {performances.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Hráč zatím není přiřazen k žádnému představení.</p>
+            ) : (
+                <ul className="divide-y divide-border">
+                    {performances.map((performance) => (
+                        <li key={performance.id} className="flex items-center justify-between py-3">
+                            <div>
+                                <span className="font-medium">{performance.name}</span>
+                                <span className="ml-3 text-sm text-muted-foreground">{formatDate(performance.date)}</span>
+                            </div>
+                            <Button variant="outline" size="sm" asChild>
+                                <Link href={`/admin/performances/${performance.id}`}>Detail</Link>
+                            </Button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/components/admin/players/PlayerPerformances.tsx
+++ b/components/admin/players/PlayerPerformances.tsx
@@ -13,18 +13,17 @@ export function PlayerPerformances({ performances }: Props) {
         <div className="space-y-3">
             <h2 className="text-xl font-semibold">Představení</h2>
             {performances.length === 0 ? (
-                <p className="text-sm text-muted-foreground">Hráč zatím není přiřazen k žádnému představení.</p>
+                <p className="text-sm text-muted-foreground">Improvizátor zatím není přiřazen k žádnému představení.</p>
             ) : (
                 <ul className="divide-y divide-border">
                     {performances.map((performance) => (
                         <li key={performance.id} className="flex items-center justify-between py-3">
-                            <div>
-                                <span className="font-medium">{performance.name}</span>
-                                <span className="ml-3 text-sm text-muted-foreground">{formatDate(performance.date)}</span>
-                            </div>
-                            <Button variant="outline" size="sm" asChild>
-                                <Link href={`/admin/performances/${performance.id}`}>Detail</Link>
-                            </Button>
+                            <Link href={`/admin/performances/${performance.id}`}>
+                                <div>
+                                    <span className="font-medium">{performance.name}</span>
+                                    <span className="ml-3 text-sm text-muted-foreground">{formatDate(performance.date)}</span>
+                                </div>
+                            </Link>
                         </li>
                     ))}
                 </ul>

--- a/components/admin/players/PlayerPerformances.tsx
+++ b/components/admin/players/PlayerPerformances.tsx
@@ -21,7 +21,9 @@ export function PlayerPerformances({ performances }: Props) {
                             <Link href={`/admin/performances/${performance.id}`}>
                                 <div>
                                     <span className="font-medium">{performance.name}</span>
-                                    <span className="ml-3 text-sm text-muted-foreground">{formatDate(performance.date)}</span>
+                                    <span className="ml-3 text-sm text-muted-foreground">
+                                        {formatDate(performance.date)}
+                                    </span>
                                 </div>
                             </Link>
                         </li>

--- a/components/admin/players/PlayerPhotos.tsx
+++ b/components/admin/players/PlayerPhotos.tsx
@@ -3,8 +3,8 @@
 import Image from "next/image";
 import { useRef, useState, useTransition } from "react";
 
-import { uploadPlayerPhoto } from "@/api/players.api";
 import { getPlayerPhotos } from "@/api/photos.api";
+import { uploadPlayerPhoto } from "@/api/players.api";
 import type { Player } from "@/api/types.api";
 import { Button } from "@/components/ui/Button";
 

--- a/components/admin/players/PlayerPhotos.tsx
+++ b/components/admin/players/PlayerPhotos.tsx
@@ -111,7 +111,7 @@ function PhotoSlot({ playerId, kind, serverUrl, label }: SlotProps) {
             <input
                 ref={inputRef}
                 type="file"
-                accept="image/*"
+                accept=".jpg,.jpeg,image/jpeg"
                 className="hidden"
                 onChange={handleFileChange}
                 aria-label={`Vybrat fotografii: ${label}`}

--- a/components/admin/players/PlayerPhotos.tsx
+++ b/components/admin/players/PlayerPhotos.tsx
@@ -118,7 +118,7 @@ function PhotoSlot({ playerId, kind, serverUrl, label }: SlotProps) {
             />
             <div className="flex gap-2">
                 <Button variant="outline" size="sm" type="button" onClick={() => inputRef.current?.click()}>
-                    Vybrat soubor
+                    Nahrát .JPG fotku
                 </Button>
                 {selectedFile && (
                     <Button size="sm" type="button" onClick={handleUpload} disabled={isPending}>

--- a/components/admin/players/PlayerPhotos.tsx
+++ b/components/admin/players/PlayerPhotos.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Image from "next/image";
+import { useRef, useState, useTransition } from "react";
+
+import { uploadPlayerPhoto } from "@/api/players.api";
+import { getPlayerPhotos } from "@/api/photos.api";
+import type { Player } from "@/api/types.api";
+import { Button } from "@/components/ui/Button";
+
+function toJpeg(file: File): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+        const objectUrl = URL.createObjectURL(file);
+        const img = new window.Image();
+        img.onload = () => {
+            URL.revokeObjectURL(objectUrl);
+            const canvas = document.createElement("canvas");
+            canvas.width = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+            canvas.getContext("2d")!.drawImage(img, 0, 0);
+            canvas.toBlob(
+                (blob) => (blob ? resolve(blob) : reject(new Error("Konverze na JPEG selhala"))),
+                "image/jpeg",
+                0.92,
+            );
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error("Načtení obrázku selhalo"));
+        };
+        img.src = objectUrl;
+    });
+}
+
+type SlotProps = {
+    playerId: number;
+    kind: "profile" | "body";
+    serverUrl: string;
+    label: string;
+};
+
+function PhotoSlot({ playerId, kind, serverUrl, label }: SlotProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [selectedFile, setSelectedFile] = useState<File | null>(null);
+    const [cacheBust, setCacheBust] = useState(0);
+    const [serverImgError, setServerImgError] = useState(false);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const [isPending, startTransition] = useTransition();
+
+    function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        if (previewUrl) URL.revokeObjectURL(previewUrl);
+        setSelectedFile(file);
+        setPreviewUrl(URL.createObjectURL(file));
+        setUploadError(null);
+    }
+
+    function handleUpload() {
+        if (!selectedFile) return;
+        setUploadError(null);
+        startTransition(async () => {
+            try {
+                const blob = await toJpeg(selectedFile);
+                const fd = new FormData();
+                fd.append("photo", blob, `${kind}.jpg`);
+                const result = await uploadPlayerPhoto(playerId, kind, fd);
+                if (!result.success) {
+                    setUploadError(result.error);
+                    return;
+                }
+                if (previewUrl) URL.revokeObjectURL(previewUrl);
+                setPreviewUrl(null);
+                setSelectedFile(null);
+                if (inputRef.current) inputRef.current.value = "";
+                setServerImgError(false);
+                setCacheBust((n) => n + 1);
+            } catch (e) {
+                setUploadError(e instanceof Error ? e.message : "Chyba při nahrávání");
+            }
+        });
+    }
+
+    const isPreview = !!previewUrl;
+    const displayUrl = previewUrl ?? `${serverUrl}?t=${cacheBust}`;
+
+    return (
+        <div className="space-y-3">
+            <p className="text-sm font-medium">{label}</p>
+            <div className="relative h-48 w-36 overflow-hidden rounded-lg border border-border bg-muted">
+                {!serverImgError || isPreview ? (
+                    <Image
+                        key={displayUrl}
+                        src={displayUrl}
+                        alt={label}
+                        fill
+                        sizes="144px"
+                        className="object-cover"
+                        onError={() => {
+                            if (!isPreview) setServerImgError(true);
+                        }}
+                        unoptimized={isPreview}
+                    />
+                ) : (
+                    <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+                        Bez fotografie
+                    </div>
+                )}
+            </div>
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleFileChange}
+                aria-label={`Vybrat fotografii: ${label}`}
+            />
+            <div className="flex gap-2">
+                <Button variant="outline" size="sm" type="button" onClick={() => inputRef.current?.click()}>
+                    Vybrat soubor
+                </Button>
+                {selectedFile && (
+                    <Button size="sm" type="button" onClick={handleUpload} disabled={isPending}>
+                        {isPending ? "Nahrávám..." : "Nahrát"}
+                    </Button>
+                )}
+            </div>
+            {selectedFile && !isPending && (
+                <p className="text-xs text-muted-foreground">Vybraný: {selectedFile.name}</p>
+            )}
+            {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+        </div>
+    );
+}
+
+type Props = {
+    player: Player;
+};
+
+export function PlayerPhotos({ player }: Props) {
+    const { profile, body } = getPlayerPhotos(player.id);
+
+    return (
+        <div className="space-y-4">
+            <h2 className="text-xl font-semibold">Fotografie</h2>
+            <div className="flex flex-wrap gap-8">
+                <PhotoSlot playerId={player.id} kind="profile" serverUrl={profile} label="Profilová fotografie" />
+                <PhotoSlot playerId={player.id} kind="body" serverUrl={body} label="Celkové foto" />
+            </div>
+        </div>
+    );
+}

--- a/components/admin/question-pools/DeletePoolButton.tsx
+++ b/components/admin/question-pools/DeletePoolButton.tsx
@@ -31,7 +31,12 @@ export const DeletePoolButton = ({ pool }: Props) => {
 
     return (
         <div className={"flex flex-col gap-2"}>
-            <Button variant="outline" className={"border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"} onClick={handleDelete} disabled={loading}>
+            <Button
+                variant="outline"
+                className={"hover:bg-destructive/10 border-destructive text-destructive hover:text-destructive"}
+                onClick={handleDelete}
+                disabled={loading}
+            >
                 <Trash2 size={16} />
                 {loading ? "Mazání…" : "Smazat skupinu"}
             </Button>

--- a/components/admin/questions/QuestionSidebarRow.tsx
+++ b/components/admin/questions/QuestionSidebarRow.tsx
@@ -30,7 +30,7 @@ export const QuestionSidebarRow = ({ question, selected }: Props) => {
                 <SmartphoneIcon
                     size={14}
                     className={userActive ? "text-amber" : "text-muted-foreground"}
-                    aria-label={"Hráči"}
+                    aria-label={"Diváck"}
                 />
                 <ProjectorIcon
                     size={14}

--- a/components/admin/questions/QuestionSidebarRow.tsx
+++ b/components/admin/questions/QuestionSidebarRow.tsx
@@ -30,7 +30,7 @@ export const QuestionSidebarRow = ({ question, selected }: Props) => {
                 <SmartphoneIcon
                     size={14}
                     className={userActive ? "text-amber" : "text-muted-foreground"}
-                    aria-label={"Diváck"}
+                    aria-label={"Diváci (telefon)"}
                 />
                 <ProjectorIcon
                     size={14}

--- a/components/ui/Table.tsx
+++ b/components/ui/Table.tsx
@@ -27,7 +27,7 @@ const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttribut
     ({ className, ...props }, ref) => (
         <tfoot
             ref={ref}
-            className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+            className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
             {...props}
         />
     ),
@@ -38,7 +38,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     ({ className, ...props }, ref) => (
         <tr
             ref={ref}
-            className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)}
+            className={cn("hover:bg-muted/50 border-b transition-colors data-[state=selected]:bg-muted", className)}
             {...props}
         />
     ),

--- a/components/ui/UserFormattedContent.tsx
+++ b/components/ui/UserFormattedContent.tsx
@@ -7,14 +7,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const UseFormattedContent = React.forwardRef<HTMLDivElement, Props>(({ className, html, ...props }, ref) => {
-    return (
-        <div
-            className={cn("text-lg", className)}
-            ref={ref}
-            {...props}
-            dangerouslySetInnerHTML={{ __html: html }}
-        />
-    );
+    return <div className={cn("text-lg", className)} ref={ref} {...props} dangerouslySetInnerHTML={{ __html: html }} />;
 });
 
 export { UseFormattedContent };

--- a/components/users/onboarding/OnboardingPracticeQuestion.tsx
+++ b/components/users/onboarding/OnboardingPracticeQuestion.tsx
@@ -69,7 +69,7 @@ export const OnboardingPracticeQuestion = ({ onComplete, hasMottoQuestion }: Pro
         <>
             <h2 className="text-2xl font-bold">Ukázka hlasování</h2>
             <Paragraph>
-                Takhle bude vypadat hlasování. Hráči se zobrazí v náhodném pořadí. Stačí kliknout. Vybraný se označí
+                Takhle bude vypadat hlasování. Improvizátoři se zobrazí v náhodném pořadí. Stačí kliknout. Vybraný se označí
                 bíle.
             </Paragraph>
             <Paragraph>Rozhodnutí můžete libovolně měnit dokud moderátor neukončí hlasování.</Paragraph>

--- a/components/users/onboarding/OnboardingPracticeQuestion.tsx
+++ b/components/users/onboarding/OnboardingPracticeQuestion.tsx
@@ -69,8 +69,8 @@ export const OnboardingPracticeQuestion = ({ onComplete, hasMottoQuestion }: Pro
         <>
             <h2 className="text-2xl font-bold">Ukázka hlasování</h2>
             <Paragraph>
-                Takhle bude vypadat hlasování. Improvizátoři se zobrazí v náhodném pořadí. Stačí kliknout. Vybraný se označí
-                bíle.
+                Takhle bude vypadat hlasování. Improvizátoři se zobrazí v náhodném pořadí. Stačí kliknout. Vybraný se
+                označí bíle.
             </Paragraph>
             <Paragraph>Rozhodnutí můžete libovolně měnit dokud moderátor neukončí hlasování.</Paragraph>
             <Paragraph>Odpovědi není třeba potvrzovat žádným tlačítkem.</Paragraph>

--- a/components/users/questions/OptionsQuestion.tsx
+++ b/components/users/questions/OptionsQuestion.tsx
@@ -90,8 +90,8 @@ export const OptionsQuestion = ({ navigateNext, skipQuestion, isOptional, isChai
                         className={cn(
                             "cursor-pointer rounded-[12px] border-2 border-transparent px-4 py-3.5 text-sm font-medium leading-snug transition-all duration-200",
                             selectedOption === option.id
-                                ? "border-primary [background:var(--amber-dim)] text-foreground"
-                                : "border-border bg-card text-foreground hover:border-border/60",
+                                ? "border-primary text-foreground [background:var(--amber-dim)]"
+                                : "hover:border-border/60 border-border bg-card text-foreground",
                         )}
                         onClick={() =>
                             hasFollowingQuestion ? setSelectedOption(option.id) : handleAutoSubmit(option.id)

--- a/components/users/questions/UserQuestionDetail.tsx
+++ b/components/users/questions/UserQuestionDetail.tsx
@@ -92,11 +92,7 @@ export const UserQuestionDetail = ({ question: initialQuestion }: Props) => {
     switch (question.type) {
         case "info":
             component = (
-                <InfoQuestion
-                    questionId={question.id}
-                    questionText={question.question}
-                    navigateNext={navigateNext}
-                />
+                <InfoQuestion questionId={question.id} questionText={question.question} navigateNext={navigateNext} />
             );
             break;
         case "text":
@@ -164,7 +160,7 @@ export const UserQuestionDetail = ({ question: initialQuestion }: Props) => {
     return (
         <div className="flex min-h-svh flex-col pb-10">
             {showModificationNotice && <ModificationNotice />}
-            <div className="sticky top-0 z-10 bg-gradient-to-b from-background via-background/95 to-transparent px-6 pb-4 pt-6">
+            <div className="via-background/95 sticky top-0 z-10 bg-gradient-to-b from-background to-transparent px-6 pb-4 pt-6">
                 <h2 className="text-[22px] font-bold leading-snug">{question.name}</h2>
             </div>
             <div className="flex flex-col gap-4 px-6 pt-2">{component}</div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,29 +11,39 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
     baseDirectory: __dirname,
     recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+    allConfig: js.configs.all,
 });
 
-export default defineConfig([{
-    extends: [...nextCoreWebVitals, ...compat.extends("prettier")],
+export default defineConfig([
+    {
+        extends: [...nextCoreWebVitals, ...compat.extends("prettier")],
 
-    rules: {
-        "no-restricted-imports": ["warn", {
-            patterns: [{
-                group: [".*"],
-                message: "Relative imports are not allowed, use absolute import instead.",
-            }],
-        }],
+        rules: {
+            "no-restricted-imports": [
+                "warn",
+                {
+                    patterns: [
+                        {
+                            group: [".*"],
+                            message: "Relative imports are not allowed, use absolute import instead.",
+                        },
+                    ],
+                },
+            ],
 
-        "react/display-name": "off",
-        "import/no-absolute-path": "off",
+            "react/display-name": "off",
+            "import/no-absolute-path": "off",
 
-        "import/order": ["warn", {
-            alphabetize: {
-                order: "asc",
-            },
+            "import/order": [
+                "warn",
+                {
+                    alphabetize: {
+                        order: "asc",
+                    },
 
-            "newlines-between": "always",
-        }],
+                    "newlines-between": "always",
+                },
+            ],
+        },
     },
-}]);
+]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,29 +1,26 @@
-const nextJest = require('next/jest')
+const nextJest = require("next/jest");
 
 const createJestConfig = nextJest({
-  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: './',
-})
+    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+    dir: "./",
+});
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  testEnvironment: 'jest-environment-jsdom',
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
-  },
-  testMatch: [
-    '<rootDir>/tests/**/*.test.ts',
-    '<rootDir>/tests/**/*.test.tsx',
-  ],
-  collectCoverageFrom: [
-    'api/**/*.ts',
-    'app/**/*.{ts,tsx}',
-    'components/**/*.{ts,tsx}',
-    '!**/*.d.ts',
-    '!**/node_modules/**',
-  ],
-}
+    setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+    testEnvironment: "jest-environment-jsdom",
+    moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/$1",
+    },
+    testMatch: ["<rootDir>/tests/**/*.test.ts", "<rootDir>/tests/**/*.test.tsx"],
+    collectCoverageFrom: [
+        "api/**/*.ts",
+        "app/**/*.{ts,tsx}",
+        "components/**/*.{ts,tsx}",
+        "!**/*.d.ts",
+        "!**/node_modules/**",
+    ],
+};
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig)
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,39 +1,39 @@
-import '@testing-library/jest-dom'
+import "@testing-library/jest-dom";
 
 // Mock Supabase client
-jest.mock('./utils/supabase/client', () => ({
-  createClient: jest.fn(() => ({
-    from: jest.fn(),
-    auth: {
-      getUser: jest.fn(),
-      signInWithPassword: jest.fn(),
-    },
-  })),
-}))
+jest.mock("./utils/supabase/client", () => ({
+    createClient: jest.fn(() => ({
+        from: jest.fn(),
+        auth: {
+            getUser: jest.fn(),
+            signInWithPassword: jest.fn(),
+        },
+    })),
+}));
 
 // Mock Supabase server client
-jest.mock('./utils/supabase/server', () => ({
-  createClient: jest.fn(() => ({
-    from: jest.fn(),
-    auth: {
-      getUser: jest.fn(),
-    },
-  })),
-}))
+jest.mock("./utils/supabase/server", () => ({
+    createClient: jest.fn(() => ({
+        from: jest.fn(),
+        auth: {
+            getUser: jest.fn(),
+        },
+    })),
+}));
 
 // Mock React cache
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  cache: (fn) => fn, // Passthrough for testing
-}))
+jest.mock("react", () => ({
+    ...jest.requireActual("react"),
+    cache: (fn) => fn, // Passthrough for testing
+}));
 
 // Mock next/navigation
-jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-    prefetch: jest.fn(),
-  }),
-  usePathname: () => '',
-  useSearchParams: () => new URLSearchParams(),
-}))
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: jest.fn(),
+        replace: jest.fn(),
+        prefetch: jest.fn(),
+    }),
+    usePathname: () => "",
+    useSearchParams: () => new URLSearchParams(),
+}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,20 +18,10 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "target": "ES2017"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/utils/supabase/entity.types.ts
+++ b/utils/supabase/entity.types.ts
@@ -1,613 +1,584 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "13.0.5"
-  }
-  public: {
-    Tables: {
-      answers_match: {
-        Row: {
-          character_id: number
-          id: number
-          player_id: number
-          question_id: number
-          user_id: string
-        }
-        Insert: {
-          character_id: number
-          id?: number
-          player_id: number
-          question_id: number
-          user_id: string
-        }
-        Update: {
-          character_id?: number
-          id?: number
-          player_id?: number
-          question_id?: number
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "answers_match_character_id_fkey"
-            columns: ["character_id"]
-            isOneToOne: false
-            referencedRelation: "characters"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "answers_match_player_id_fkey"
-            columns: ["player_id"]
-            isOneToOne: false
-            referencedRelation: "players"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "answers_match_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      answers_options: {
-        Row: {
-          id: number
-          question_id: number
-          question_options_id: number
-          user_id: string
-        }
-        Insert: {
-          id?: number
-          question_id: number
-          question_options_id: number
-          user_id: string
-        }
-        Update: {
-          id?: number
-          question_id?: number
-          question_options_id?: number
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "answers_options_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "answers_options_question_options_id_fkey"
-            columns: ["question_options_id"]
-            isOneToOne: false
-            referencedRelation: "questions_options"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      answers_text: {
-        Row: {
-          drawn: number | null
-          favorite: boolean
-          id: number
-          question_id: number
-          user_id: string
-          value: string
-        }
-        Insert: {
-          drawn?: number | null
-          favorite?: boolean
-          id?: number
-          question_id: number
-          user_id: string
-          value: string
-        }
-        Update: {
-          drawn?: number | null
-          favorite?: boolean
-          id?: number
-          question_id?: number
-          user_id?: string
-          value?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "answers_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      answers_vote: {
-        Row: {
-          id: number
-          player_id: number
-          question_id: number
-          user_id: string
-        }
-        Insert: {
-          id?: number
-          player_id: number
-          question_id: number
-          user_id: string
-        }
-        Update: {
-          id?: number
-          player_id?: number
-          question_id?: number
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "answer_votes_player_id_fkey"
-            columns: ["player_id"]
-            isOneToOne: false
-            referencedRelation: "players"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "answer_votes_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      characters: {
-        Row: {
-          description: string | null
-          id: number
-          name: string
-          question_id: number
-        }
-        Insert: {
-          description?: string | null
-          id?: number
-          name: string
-          question_id: number
-        }
-        Update: {
-          description?: string | null
-          id?: number
-          name?: string
-          question_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "question_names_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      performances: {
-        Row: {
-          date: string
-          id: number
-          intro_text: string
-          name: string
-          note: string | null
-          state: Database["public"]["Enums"]["performance-state"]
-          url_slug: string
-        }
-        Insert: {
-          date: string
-          id?: number
-          intro_text: string
-          name: string
-          note?: string | null
-          state: Database["public"]["Enums"]["performance-state"]
-          url_slug: string
-        }
-        Update: {
-          date?: string
-          id?: number
-          intro_text?: string
-          name?: string
-          note?: string | null
-          state?: Database["public"]["Enums"]["performance-state"]
-          url_slug?: string
-        }
-        Relationships: []
-      }
-      performances_players: {
-        Row: {
-          performance_id: number
-          player_id: number
-        }
-        Insert: {
-          performance_id: number
-          player_id: number
-        }
-        Update: {
-          performance_id?: number
-          player_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "performance_players_performance_id_fkey"
-            columns: ["performance_id"]
-            isOneToOne: false
-            referencedRelation: "performances"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "performance_players_player_id_fkey"
-            columns: ["player_id"]
-            isOneToOne: false
-            referencedRelation: "players"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      players: {
-        Row: {
-          id: number
-          motto: string | null
-          name: string
-          quest: boolean | null
-          surname: string | null
-        }
-        Insert: {
-          id?: number
-          motto?: string | null
-          name: string
-          quest?: boolean | null
-          surname?: string | null
-        }
-        Update: {
-          id?: number
-          motto?: string | null
-          name?: string
-          quest?: boolean | null
-          surname?: string | null
-        }
-        Relationships: []
-      }
-      questions: {
-        Row: {
-          audience_visibility: Database["public"]["Enums"]["audience_visibility"]
-          following_question_id: number | null
-          id: number
-          index_order: number
-          multiple: boolean
-          name: string
-          optional: boolean
-          performance_id: number
-          pool_id: number | null
-          question: string
-          show_player_motto: boolean
-          state: Database["public"]["Enums"]["question-state"]
-          type: Database["public"]["Enums"]["question-type"]
-        }
-        Insert: {
-          audience_visibility?: Database["public"]["Enums"]["audience_visibility"]
-          following_question_id?: number | null
-          id?: number
-          index_order: number
-          multiple?: boolean
-          name: string
-          optional?: boolean
-          performance_id: number
-          pool_id?: number | null
-          question: string
-          show_player_motto?: boolean
-          state: Database["public"]["Enums"]["question-state"]
-          type?: Database["public"]["Enums"]["question-type"]
-        }
-        Update: {
-          audience_visibility?: Database["public"]["Enums"]["audience_visibility"]
-          following_question_id?: number | null
-          id?: number
-          index_order?: number
-          multiple?: boolean
-          name?: string
-          optional?: boolean
-          performance_id?: number
-          pool_id?: number | null
-          question?: string
-          show_player_motto?: boolean
-          state?: Database["public"]["Enums"]["question-state"]
-          type?: Database["public"]["Enums"]["question-type"]
-        }
-        Relationships: [
-          {
-            foreignKeyName: "questions_following_question_id_fkey"
-            columns: ["following_question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "questions_performance_id_fkey"
-            columns: ["performance_id"]
-            isOneToOne: false
-            referencedRelation: "performances"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "questions_pool_id_fkey"
-            columns: ["pool_id"]
-            isOneToOne: false
-            referencedRelation: "questions_pool"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      questions_options: {
-        Row: {
-          id: number
-          option: string | null
-          question_id: number
-        }
-        Insert: {
-          id?: number
-          option?: string | null
-          question_id: number
-        }
-        Update: {
-          id?: number
-          option?: string | null
-          question_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "questions_options_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      questions_players: {
-        Row: {
-          player_id: number
-          question_id: number
-        }
-        Insert: {
-          player_id: number
-          question_id: number
-        }
-        Update: {
-          player_id?: number
-          question_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "question_players_player_id_fkey"
-            columns: ["player_id"]
-            isOneToOne: false
-            referencedRelation: "players"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "question_players_question_id_fkey"
-            columns: ["question_id"]
-            isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      questions_pool: {
-        Row: {
-          audience_visibility: boolean
-          id: number
-          name: string | null
-          performance_id: number
-        }
-        Insert: {
-          audience_visibility?: boolean
-          id?: number
-          name?: string | null
-          performance_id: number
-        }
-        Update: {
-          audience_visibility?: boolean
-          id?: number
-          name?: string | null
-          performance_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "questions_pool_performance_id_fkey"
-            columns: ["performance_id"]
-            isOneToOne: false
-            referencedRelation: "performances"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      get_match_results: {
-        Args: { question_id_param: number }
-        Returns: {
-          count: number
-          player_id: number
-          value: string
-        }[]
-      }
-      get_value_counts_by_player: {
-        Args: { question_id_param: number }
-        Returns: {
-          count: number
-          player_id: number
-          value: string
-        }[]
-      }
-    }
-    Enums: {
-      audience_visibility: "hidden" | "question" | "results"
-      "performance-state": "draft" | "intro" | "life" | "finished" | "closing"
-      "question-state": "hidden" | "active" | "locked"
-      "question-type":
-        | "text"
-        | "player-pick"
-        | "voting"
-        | "match"
-        | "options"
-        | "info"
-        | "select"
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+    // Allows to automatically instantiate createClient with right options
+    // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+    __InternalSupabase: {
+        PostgrestVersion: "13.0.5";
+    };
+    public: {
+        Tables: {
+            answers_match: {
+                Row: {
+                    character_id: number;
+                    id: number;
+                    player_id: number;
+                    question_id: number;
+                    user_id: string;
+                };
+                Insert: {
+                    character_id: number;
+                    id?: number;
+                    player_id: number;
+                    question_id: number;
+                    user_id: string;
+                };
+                Update: {
+                    character_id?: number;
+                    id?: number;
+                    player_id?: number;
+                    question_id?: number;
+                    user_id?: string;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "answers_match_character_id_fkey";
+                        columns: ["character_id"];
+                        isOneToOne: false;
+                        referencedRelation: "characters";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "answers_match_player_id_fkey";
+                        columns: ["player_id"];
+                        isOneToOne: false;
+                        referencedRelation: "players";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "answers_match_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            answers_options: {
+                Row: {
+                    id: number;
+                    question_id: number;
+                    question_options_id: number;
+                    user_id: string;
+                };
+                Insert: {
+                    id?: number;
+                    question_id: number;
+                    question_options_id: number;
+                    user_id: string;
+                };
+                Update: {
+                    id?: number;
+                    question_id?: number;
+                    question_options_id?: number;
+                    user_id?: string;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "answers_options_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "answers_options_question_options_id_fkey";
+                        columns: ["question_options_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions_options";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            answers_text: {
+                Row: {
+                    drawn: number | null;
+                    favorite: boolean;
+                    id: number;
+                    question_id: number;
+                    user_id: string;
+                    value: string;
+                };
+                Insert: {
+                    drawn?: number | null;
+                    favorite?: boolean;
+                    id?: number;
+                    question_id: number;
+                    user_id: string;
+                    value: string;
+                };
+                Update: {
+                    drawn?: number | null;
+                    favorite?: boolean;
+                    id?: number;
+                    question_id?: number;
+                    user_id?: string;
+                    value?: string;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "answers_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            answers_vote: {
+                Row: {
+                    id: number;
+                    player_id: number;
+                    question_id: number;
+                    user_id: string;
+                };
+                Insert: {
+                    id?: number;
+                    player_id: number;
+                    question_id: number;
+                    user_id: string;
+                };
+                Update: {
+                    id?: number;
+                    player_id?: number;
+                    question_id?: number;
+                    user_id?: string;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "answer_votes_player_id_fkey";
+                        columns: ["player_id"];
+                        isOneToOne: false;
+                        referencedRelation: "players";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "answer_votes_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            characters: {
+                Row: {
+                    description: string | null;
+                    id: number;
+                    name: string;
+                    question_id: number;
+                };
+                Insert: {
+                    description?: string | null;
+                    id?: number;
+                    name: string;
+                    question_id: number;
+                };
+                Update: {
+                    description?: string | null;
+                    id?: number;
+                    name?: string;
+                    question_id?: number;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "question_names_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            performances: {
+                Row: {
+                    date: string;
+                    id: number;
+                    intro_text: string;
+                    name: string;
+                    note: string | null;
+                    state: Database["public"]["Enums"]["performance-state"];
+                    url_slug: string;
+                };
+                Insert: {
+                    date: string;
+                    id?: number;
+                    intro_text: string;
+                    name: string;
+                    note?: string | null;
+                    state: Database["public"]["Enums"]["performance-state"];
+                    url_slug: string;
+                };
+                Update: {
+                    date?: string;
+                    id?: number;
+                    intro_text?: string;
+                    name?: string;
+                    note?: string | null;
+                    state?: Database["public"]["Enums"]["performance-state"];
+                    url_slug?: string;
+                };
+                Relationships: [];
+            };
+            performances_players: {
+                Row: {
+                    performance_id: number;
+                    player_id: number;
+                };
+                Insert: {
+                    performance_id: number;
+                    player_id: number;
+                };
+                Update: {
+                    performance_id?: number;
+                    player_id?: number;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "performance_players_performance_id_fkey";
+                        columns: ["performance_id"];
+                        isOneToOne: false;
+                        referencedRelation: "performances";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "performance_players_player_id_fkey";
+                        columns: ["player_id"];
+                        isOneToOne: false;
+                        referencedRelation: "players";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            players: {
+                Row: {
+                    id: number;
+                    motto: string | null;
+                    name: string;
+                    quest: boolean | null;
+                    surname: string | null;
+                };
+                Insert: {
+                    id?: number;
+                    motto?: string | null;
+                    name: string;
+                    quest?: boolean | null;
+                    surname?: string | null;
+                };
+                Update: {
+                    id?: number;
+                    motto?: string | null;
+                    name?: string;
+                    quest?: boolean | null;
+                    surname?: string | null;
+                };
+                Relationships: [];
+            };
+            questions: {
+                Row: {
+                    audience_visibility: Database["public"]["Enums"]["audience_visibility"];
+                    following_question_id: number | null;
+                    id: number;
+                    index_order: number;
+                    multiple: boolean;
+                    name: string;
+                    optional: boolean;
+                    performance_id: number;
+                    pool_id: number | null;
+                    question: string;
+                    show_player_motto: boolean;
+                    state: Database["public"]["Enums"]["question-state"];
+                    type: Database["public"]["Enums"]["question-type"];
+                };
+                Insert: {
+                    audience_visibility?: Database["public"]["Enums"]["audience_visibility"];
+                    following_question_id?: number | null;
+                    id?: number;
+                    index_order: number;
+                    multiple?: boolean;
+                    name: string;
+                    optional?: boolean;
+                    performance_id: number;
+                    pool_id?: number | null;
+                    question: string;
+                    show_player_motto?: boolean;
+                    state: Database["public"]["Enums"]["question-state"];
+                    type?: Database["public"]["Enums"]["question-type"];
+                };
+                Update: {
+                    audience_visibility?: Database["public"]["Enums"]["audience_visibility"];
+                    following_question_id?: number | null;
+                    id?: number;
+                    index_order?: number;
+                    multiple?: boolean;
+                    name?: string;
+                    optional?: boolean;
+                    performance_id?: number;
+                    pool_id?: number | null;
+                    question?: string;
+                    show_player_motto?: boolean;
+                    state?: Database["public"]["Enums"]["question-state"];
+                    type?: Database["public"]["Enums"]["question-type"];
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "questions_following_question_id_fkey";
+                        columns: ["following_question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "questions_performance_id_fkey";
+                        columns: ["performance_id"];
+                        isOneToOne: false;
+                        referencedRelation: "performances";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "questions_pool_id_fkey";
+                        columns: ["pool_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions_pool";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            questions_options: {
+                Row: {
+                    id: number;
+                    option: string | null;
+                    question_id: number;
+                };
+                Insert: {
+                    id?: number;
+                    option?: string | null;
+                    question_id: number;
+                };
+                Update: {
+                    id?: number;
+                    option?: string | null;
+                    question_id?: number;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "questions_options_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            questions_players: {
+                Row: {
+                    player_id: number;
+                    question_id: number;
+                };
+                Insert: {
+                    player_id: number;
+                    question_id: number;
+                };
+                Update: {
+                    player_id?: number;
+                    question_id?: number;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "question_players_player_id_fkey";
+                        columns: ["player_id"];
+                        isOneToOne: false;
+                        referencedRelation: "players";
+                        referencedColumns: ["id"];
+                    },
+                    {
+                        foreignKeyName: "question_players_question_id_fkey";
+                        columns: ["question_id"];
+                        isOneToOne: false;
+                        referencedRelation: "questions";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+            questions_pool: {
+                Row: {
+                    audience_visibility: boolean;
+                    id: number;
+                    name: string | null;
+                    performance_id: number;
+                };
+                Insert: {
+                    audience_visibility?: boolean;
+                    id?: number;
+                    name?: string | null;
+                    performance_id: number;
+                };
+                Update: {
+                    audience_visibility?: boolean;
+                    id?: number;
+                    name?: string | null;
+                    performance_id?: number;
+                };
+                Relationships: [
+                    {
+                        foreignKeyName: "questions_pool_performance_id_fkey";
+                        columns: ["performance_id"];
+                        isOneToOne: false;
+                        referencedRelation: "performances";
+                        referencedColumns: ["id"];
+                    },
+                ];
+            };
+        };
+        Views: {
+            [_ in never]: never;
+        };
+        Functions: {
+            get_match_results: {
+                Args: { question_id_param: number };
+                Returns: {
+                    count: number;
+                    player_id: number;
+                    value: string;
+                }[];
+            };
+            get_value_counts_by_player: {
+                Args: { question_id_param: number };
+                Returns: {
+                    count: number;
+                    player_id: number;
+                    value: string;
+                }[];
+            };
+        };
+        Enums: {
+            audience_visibility: "hidden" | "question" | "results";
+            "performance-state": "draft" | "intro" | "life" | "finished" | "closing";
+            "question-state": "hidden" | "active" | "locked";
+            "question-type": "text" | "player-pick" | "voting" | "match" | "options" | "info" | "select";
+        };
+        CompositeTypes: {
+            [_ in never]: never;
+        };
+    };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+    DefaultSchemaTableNameOrOptions extends
+        | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+        | { schema: keyof DatabaseWithoutInternals },
+    TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof DatabaseWithoutInternals;
     }
-    ? R
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+        ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+              DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+        : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+}
+    ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+          DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+          Row: infer R;
       }
-      ? R
-      : never
-    : never
+        ? R
+        : never
+    : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+      ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+            Row: infer R;
+        }
+          ? R
+          : never
+      : never;
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+    DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+    TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof DatabaseWithoutInternals;
     }
-    ? I
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+        : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+}
+    ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+          Insert: infer I;
       }
-      ? I
-      : never
-    : never
+        ? I
+        : never
+    : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+      ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+            Insert: infer I;
+        }
+          ? I
+          : never
+      : never;
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+    DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+    TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof DatabaseWithoutInternals;
     }
-    ? U
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+        : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+}
+    ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+          Update: infer U;
       }
-      ? U
-      : never
-    : never
+        ? U
+        : never
+    : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+      ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+            Update: infer U;
+        }
+          ? U
+          : never
+      : never;
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+    EnumName extends DefaultSchemaEnumNameOrOptions extends {
+        schema: keyof DatabaseWithoutInternals;
+    }
+        ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+        : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+    : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+      ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+      : never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+    PublicCompositeTypeNameOrOptions extends
+        | keyof DefaultSchema["CompositeTypes"]
+        | { schema: keyof DatabaseWithoutInternals },
+    CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+        schema: keyof DatabaseWithoutInternals;
+    }
+        ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+        : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+    : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+      ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+      : never;
 
 export const Constants = {
-  public: {
-    Enums: {
-      audience_visibility: ["hidden", "question", "results"],
-      "performance-state": ["draft", "intro", "life", "finished", "closing"],
-      "question-state": ["hidden", "active", "locked"],
-      "question-type": [
-        "text",
-        "player-pick",
-        "voting",
-        "match",
-        "options",
-        "info",
-        "select",
-      ],
+    public: {
+        Enums: {
+            audience_visibility: ["hidden", "question", "results"],
+            "performance-state": ["draft", "intro", "life", "finished", "closing"],
+            "question-state": ["hidden", "active", "locked"],
+            "question-type": ["text", "player-pick", "voting", "match", "options", "info", "select"],
+        },
     },
-  },
-} as const
+} as const;

--- a/utils/supabase/service.ts
+++ b/utils/supabase/service.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/utils/supabase/entity.types";
+
+export const createServiceClient = () =>
+    createClient<Database>(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);


### PR DESCRIPTION
## Summary

- Adds a full `/admin/players` section for managing performers: list with avatar (profile photo or colored initial fallback) and bold-name formatting, create form, and an edit page
- Edit page includes fields (name, surname, motto, host flag), photo upload for profile and full-body shots (client-side JPEG re-encode via canvas, stored in the existing `photos` Supabase bucket), and a list of performances the player is assigned to with links
- Photo uploads use a dedicated service-role Supabase client (`utils/supabase/service.ts`) to bypass RLS; the upload flow does `remove` before `upload` to force CDN cache invalidation so replaced images appear immediately
- A "Improvizátoři" nav button is added to the admin home header; clicking a player row on the list navigates to their edit page

## Test plan

- [ ] `/admin` → click "Improvizátoři" → player list renders with avatars and formatted names
- [ ] Create a new player → redirected to edit page
- [ ] Edit fields and save → changes persist
- [ ] Upload profile and body photos (`.jpg` only accepted) → images appear; re-uploading replaces the image immediately without stale cache
- [ ] Edit page shows performances the player is assigned to with working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)